### PR TITLE
Add plugin query to be able to find board-config.ini file

### DIFF
--- a/XPanel.vcxproj
+++ b/XPanel.vcxproj
@@ -123,7 +123,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_WINDOWS=0x0601;WIN32;_DEBUG;_WINDOWS;_USRDLL;SIMDATA_EXPORTS;IBM=1;XPLM200=1;XPLM210=1;XPLM300=1;XPLM301=1;XPLM302=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_WINDOWS=0x0601;WIN32;_DEBUG;_WINDOWS;_USRDLL;SIMDATA_EXPORTS;IBM=1;XPLM200=1;XPLM210=1;XPLM300=1;XPLM301=1;XPLM302=1;PLUGIN_SIGNATURE="xpanel";PLUGIN_VERSION="1.1";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)\hidapi\headers;$(SolutionDir)\LUA\include;$(SolutionDir)\SDK\CHeaders\XPLM;$(SolutionDir)\SDK\CHeaders\Widgets;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
@@ -145,7 +145,7 @@
       </FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;IBM=1;XPLM200=1;XPLM210=1;XPLM300=1;XPLM301=1;XPLM302=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;IBM=1;XPLM200=1;XPLM210=1;XPLM300=1;XPLM301=1;XPLM302=1;PLUGIN_SIGNATURE="xpanel";PLUGIN_VERSION="1.1";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalIncludeDirectories>$(SolutionDir)\hidapi\headers;$(SolutionDir)\LUA\include;$(SolutionDir)\SDK\CHeaders\XPLM;$(SolutionDir)\SDK\CHeaders\Widgets;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/src/ArduinoHomeCockpit.cpp
+++ b/src/ArduinoHomeCockpit.cpp
@@ -1,8 +1,10 @@
 #include <stdlib.h>
 #include <iostream>
+#include <filesystem>
 #include <fstream>
 #include <sstream>
 #include <regex>
+#include "XPLMPlugin.h"
 #include "ArduinoHomeCockpit.h"
 #include "UsbHidDevice.h"
 #include "logger.h"
@@ -10,9 +12,14 @@
 #define WRITE_BUFFER_SIZE 9
 #define READ_BUFFER_SIZE 9
 
+std::filesystem::path get_plugin_path();
+
 ArduinoHomeCockpit::ArduinoHomeCockpit(DeviceConfiguration& config) :UsbHidDevice(config, READ_BUFFER_SIZE, WRITE_BUFFER_SIZE)
-{
-	if (read_board_configuration("board-config.ini", config.vid, config.pid) != EXIT_SUCCESS)
+{	
+	std::filesystem::path board_config_path = get_plugin_path();
+	board_config_path /= "board-config.ini";
+
+	if (read_board_configuration(board_config_path.string(), config.vid, config.pid) != EXIT_SUCCESS)
 	{
 		Logger(TLogLevel::logERROR) << "Arduino home cockpit. Error parsing board config file" << std::endl;
 		return;

--- a/src/xpanel.cpp
+++ b/src/xpanel.cpp
@@ -81,8 +81,8 @@ PLUGIN_API int XPluginStart(
 	Logger::set_log_level(TLogLevel::logINFO);
 	Logger(TLogLevel::logINFO) << "plugin start" << std::endl;
 
-	strcpy_s(outName, 16, "XPanel ver 1.0");
-	strcpy_s(outSig, 16, "xpanel");
+	strcpy_s(outName, 16, "XPanel ver " PLUGIN_VERSION);
+	strcpy_s(outSig, 16, PLUGIN_SIGNATURE);
 	strcpy_s(outDesc, 64, "A plugin to handle control devices using hidapi interface");
 
 	g_menu_container_idx = XPLMAppendMenuItem(XPLMFindPluginsMenu(), "XPanel", 0, 0);
@@ -177,6 +177,21 @@ std::filesystem::path absolute_path(std::string aircraft_path, std::string file_
 	init_path /= file_name;
 
 	return init_path;
+}
+
+extern std::filesystem::path get_plugin_path()
+{
+	char plugin_directory[256];
+	XPLMPluginID plugin_id = XPLMFindPluginBySignature(PLUGIN_SIGNATURE);
+	if (plugin_id == XPLM_NO_PLUGIN_ID)
+	{
+		Logger(TLogLevel::logERROR) << "get_plugin_path: unable to find plugin by signature: " << PLUGIN_SIGNATURE << std::endl;
+	}
+	XPLMGetPluginInfo(plugin_id, NULL, plugin_directory, NULL, NULL);
+
+	std::filesystem::path plugin_path = std::filesystem::path(plugin_directory);
+
+	return plugin_path;
 }
 
 int init_and_start_xpanel_plugin(void)

--- a/test/mock_xplane.cpp
+++ b/test/mock_xplane.cpp
@@ -1,5 +1,6 @@
 #include "XPLMGraphics.h"
 #include "XPLMPlanes.h"
+#include "XPLMPlugin.h"
 #include "XPLMDisplay.h"
 #include "XPLMDataAccess.h"
 #include "XPLMUtilities.h"
@@ -30,6 +31,26 @@ extern void XPLMGetNthAircraftModel(int inIndex, char *outFileName, char *outPat
 {
 	strcpy_s(outFileName, 256, test_aircraft_file_name);
 	strcpy_s(outPath, 512, test_aircraft_path);
+}
+
+extern XPLMPluginID XPLMFindPluginBySignature(const char* inSignature)
+{
+	return (XPLMPluginID)0;
+}
+
+extern void XPLMGetPluginInfo(XPLMPluginID inPlugin, char* outName, char* outFilePath, char* outSignature, char* outDescription)
+{
+	if (outName)
+		strcpy(outName, "XPanel ver " PLUGIN_VERSION);
+	
+	if (outFilePath)
+		strcpy(outFilePath, "./");
+	
+	if (outSignature)
+		strcpy(outSignature, PLUGIN_SIGNATURE);
+
+	if (outDescription)
+		strcpy(outDescription, "xpanel");
 }
 
 extern XPLMMenuID XPLMFindPluginsMenu()

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -96,7 +96,7 @@
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)src;$(SolutionDir)hidapi\headers;$(SolutionDir)LUA\include;$(SolutionDir)SDK\CHeaders\XPLM;$(SolutionDir)SDK\CHeaders\Widgets;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_WINDOWS=0x0601;WIN32;_DEBUG;_WINDOWS;_USRDLL;SIMDATA_EXPORTS;IBM=1;XPLM200=1;XPLM210=1;XPLM300=1;XPLM301=1;XPLM302=1;XPLM303=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_WINDOWS=0x0601;WIN32;_DEBUG;_WINDOWS;_USRDLL;SIMDATA_EXPORTS;IBM=1;XPLM200=1;XPLM210=1;XPLM300=1;XPLM301=1;XPLM302=1;XPLM303=1;PLUGIN_SIGNATURE="xpanel";PLUGIN_VERSION="1.1";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp17</LanguageStandard>
@@ -157,7 +157,7 @@ xcopy /y /d "$(SolutionDir)config\board-config.ini" "$(OutDir)"
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>false</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)src;$(SolutionDir)hidapi\headers;$(SolutionDir)LUA\include;$(SolutionDir)SDK\CHeaders\XPLM;$(SolutionDir)SDK\CHeaders\Widgets;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_WINDOWS=0x0601;WIN32;_WINDOWS;_USRDLL;SIMDATA_EXPORTS;IBM=1;XPLM200=1;XPLM210=1;XPLM300=1;XPLM301=1;XPLM302=1;XPLM303=1;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_WINDOWS=0x0601;WIN32;_WINDOWS;_USRDLL;SIMDATA_EXPORTS;IBM=1;XPLM200=1;XPLM210=1;XPLM300=1;XPLM301=1;XPLM302=1;XPLM303=1;NDEBUG;PLUGIN_SIGNATURE="xpanel";PLUGIN_VERSION="1.1";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp17</LanguageStandard>

--- a/test/test_arduino_home.cpp
+++ b/test/test_arduino_home.cpp
@@ -3,6 +3,7 @@
 #include "XPLMPlugin.h"
 #include "XPLMPlanes.h"
 #include "XPLMDisplay.h"
+#include "XPLMPlugin.h"
 
 #include "CppUnitTest.h"
 #include "ArduinoHomeCockpit.h"

--- a/test/test_xpanel_plugin.cpp
+++ b/test/test_xpanel_plugin.cpp
@@ -44,7 +44,7 @@ namespace test
 
 		TEST_METHOD(TestPluginCheckPluginName)
 		{
-			Assert::AreEqual("XPanel ver 1.0", outName);
+			Assert::AreEqual("XPanel ver " PLUGIN_VERSION, outName);
 		}
 
 		TEST_METHOD(TestPluginReload)
@@ -54,7 +54,7 @@ namespace test
 
 			int MENU_ITEM_RELOAD = 0;
 			test_call_menu_handler(0, NULL, &MENU_ITEM_RELOAD);
-			Assert::AreEqual("XPanel ver 1.0", outName);
+			Assert::AreEqual("XPanel ver " PLUGIN_VERSION, outName);
 			
 			test_call_registered_flight_loop();
 			std::this_thread::sleep_for(150ms);


### PR DESCRIPTION
- The path to board-config.ini file is queried from Xplane
- Add preprocessor definitions for plugin signature and version
- Add build date/time to log

Signed-off-by: norberttak <norberttak@gmail.com>