### PR TITLE
license: add license identifiers and copyright notices

### DIFF
--- a/config/747-200/xpanel.ini
+++ b/config/747-200/xpanel.ini
@@ -2,6 +2,8 @@
 ;
 ; Copyright (C) 2022  Norbert Takacs <norberttak@gmail.com>
 ;
+; SPDX-License-Identifier: GPL-3.0-or-later
+;
 ; This program is free software: you can redistribute it and/or modify
 ; it under the terms of the GNU General Public License as published by
 ; the Free Software Foundation, either version 3 of the License, or

--- a/config/King Air 350/xpanel.ini
+++ b/config/King Air 350/xpanel.ini
@@ -2,6 +2,8 @@
 ;
 ; Copyright (C) 2022  Norbert Takacs <norberttak@gmail.com>
 ;
+; SPDX-License-Identifier: GPL-3.0-or-later
+;
 ; This program is free software: you can redistribute it and/or modify
 ; it under the terms of the GNU General Public License as published by
 ; the Free Software Foundation, either version 3 of the License, or

--- a/config/L200 Morava/xpanel.ini
+++ b/config/L200 Morava/xpanel.ini
@@ -2,6 +2,8 @@
 ;
 ; Copyright (C) 2022  Norbert Takacs <norberttak@gmail.com>
 ;
+; SPDX-License-Identifier: GPL-3.0-or-later
+;
 ; This program is free software: you can redistribute it and/or modify
 ; it under the terms of the GNU General Public License as published by
 ; the Free Software Foundation, either version 3 of the License, or

--- a/config/Thranda DHC2/xpanel.ini
+++ b/config/Thranda DHC2/xpanel.ini
@@ -2,6 +2,8 @@
 ;
 ; Copyright (C) 2022  Norbert Takacs <norberttak@gmail.com>
 ;
+; SPDX-License-Identifier: GPL-3.0-or-later
+;
 ; This program is free software: you can redistribute it and/or modify
 ; it under the terms of the GNU General Public License as published by
 ; the Free Software Foundation, either version 3 of the License, or
@@ -76,7 +78,7 @@ pid="d06"
 
 [button:id="HDG"]
 on_push="commandref:sim/autopilot/heading:once"
- 
+
 [button:id="NAV"]
 on_push="commandref:sim/autopilot/NAV:once"
 

--- a/config/airfoillabs c172sp/xpanel.ini
+++ b/config/airfoillabs c172sp/xpanel.ini
@@ -2,6 +2,8 @@
 ;
 ; Copyright (C) 2022  Norbert Takacs <norberttak@gmail.com>
 ;
+; SPDX-License-Identifier: GPL-3.0-or-later
+;
 ; This program is free software: you can redistribute it and/or modify
 ; it under the terms of the GNU General Public License as published by
 ; the Free Software Foundation, either version 3 of the License, or
@@ -77,7 +79,7 @@ pid="d06"
 
 [button:id="HDG"]
 on_push="commandref:172/autopilot/ap_hdg:once"
- 
+
 [button:id="NAV"]
 on_push="commandref:172/autopilot/ap_nav:once"
 

--- a/config/default c172/xpanel.ini
+++ b/config/default c172/xpanel.ini
@@ -2,6 +2,8 @@
 ;
 ; Copyright (C) 2022  Norbert Takacs <norberttak@gmail.com>
 ;
+; SPDX-License-Identifier: GPL-3.0-or-later
+;
 ; This program is free software: you can redistribute it and/or modify
 ; it under the terms of the GNU General Public License as published by
 ; the Free Software Foundation, either version 3 of the License, or
@@ -76,7 +78,7 @@ pid="d06"
 
 [button:id="HDG"]
 on_push="commandref:sim/autopilot/heading:once"
- 
+
 [button:id="NAV"]
 on_push="commandref:sim/autopilot/NAV:once"
 

--- a/config/tu154/xpanel.ini
+++ b/config/tu154/xpanel.ini
@@ -2,6 +2,8 @@
 ;
 ; Copyright (C) 2022  Norbert Takacs <norberttak@gmail.com>
 ;
+; SPDX-License-Identifier: GPL-3.0-or-later
+;
 ; This program is free software: you can redistribute it and/or modify
 ; it under the terms of the GNU General Public License as published by
 ; the Free Software Foundation, either version 3 of the License, or
@@ -99,7 +101,7 @@ on_release="dataref:sim/custom/switchers/console/absu_speed_prepare:0"
 [button:id="HDG"]
 on_push="dataref:sim/custom/buttons/console/absu_zk:1"
 on_release="dataref:sim/custom/buttons/console/absu_zk:0"
- 
+
 ;NVU button on ABSU
 [button:id="NAV"]
 on_push="dataref:sim/custom/buttons/console/absu_nvu:1"

--- a/src/Action.cpp
+++ b/src/Action.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "Action.h"
 #include "lua_helper.h"
 #include "XPLMUtilities.h"

--- a/src/Action.h
+++ b/src/Action.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #pragma once
 #include <string>
 #include <queue>
@@ -73,5 +79,3 @@ public:
 	void activate_actions_in_queue();
 	void clear_all_actions();
 };
-
-

--- a/src/ArduinoHomeCockpit.cpp
+++ b/src/ArduinoHomeCockpit.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include <stdlib.h>
 #include <iostream>
 #include <filesystem>

--- a/src/ArduinoHomeCockpit.h
+++ b/src/ArduinoHomeCockpit.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #pragma once
 #include <stdlib.h>
 #include "UsbHidDevice.h"
@@ -22,4 +28,3 @@ public:
 	void start();
 	void stop(int timeout);
 };
-

--- a/src/Device.cpp
+++ b/src/Device.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "Device.h"
 
 Device::Device(DeviceConfiguration &_config)

--- a/src/Device.h
+++ b/src/Device.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #pragma once
 #include <string>
 #include <map>

--- a/src/SaitekMultiPanel.cpp
+++ b/src/SaitekMultiPanel.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include <stdlib.h>
 #include "UsbHidDevice.h"
 #include "SaitekMultiPanel.h"

--- a/src/SaitekMultiPanel.h
+++ b/src/SaitekMultiPanel.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #pragma once
 #include <vector>
 #include "device.h"
@@ -17,4 +23,3 @@ public:
 	void start();
 	void stop(int timeout);
 };
-

--- a/src/SaitekRadioPanel.cpp
+++ b/src/SaitekRadioPanel.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include <stdlib.h>
 #include "UsbHidDevice.h"
 #include "SaitekRadioPanel.h"

--- a/src/SaitekRadioPanel.h
+++ b/src/SaitekRadioPanel.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #pragma once
 #include <vector>
 #include "device.h"
@@ -16,4 +22,3 @@ public:
 	void start();
 	void stop(int timeout);
 };
-

--- a/src/UsbHidDevice.cpp
+++ b/src/UsbHidDevice.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "UsbHidDevice.h"
 #include "logger.h"
 

--- a/src/UsbHidDevice.h
+++ b/src/UsbHidDevice.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #pragma once
 #include <stdlib.h>
 #include <thread>
@@ -97,4 +103,3 @@ private:
 	void process_and_store_button_states();
 	void process_selector_switch();
 };
-

--- a/src/configparser.cpp
+++ b/src/configparser.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include <iostream>
 #include <fstream>
 #include <sstream>

--- a/src/configparser.h
+++ b/src/configparser.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #pragma once
 #include <string>
 #include <vector>
@@ -80,4 +86,3 @@ private:
 public:
 	int parse_file(std::string file_name, Configuration& config);
 };
-

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "configuration.h"
 
 /*------ Plugin level configuration options ------------*/

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #pragma once
 #include <string>
 #include <vector>
@@ -47,4 +53,3 @@ public:
 	std::map<std::string, MultiPurposeDisplay*> multi_displays;
 	std::map<std::string, GenericDisplay*> generic_displays;
 };
-

--- a/src/generic_display.cpp
+++ b/src/generic_display.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "generic_display.h"
 #include "lua_helper.h"
 #include "logger.h"

--- a/src/generic_display.h
+++ b/src/generic_display.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #pragma once
 #include <string>
 #include <map>
@@ -40,4 +46,3 @@ private:
 	bool get_decimal_components(int number, unsigned char* buffer);
 	bool get_binary_components(int number, unsigned char* buffer);
 };
-

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "logger.h"
 
 TLogLevel Logger::current_log_level = TLogLevel::logINFO;

--- a/src/logger.h
+++ b/src/logger.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #pragma once
 #include <sstream>
 #include <list>

--- a/src/lua_helper.cpp
+++ b/src/lua_helper.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "lua_helper.h"
 #include "lua.hpp"
 #include "logger.h"

--- a/src/lua_helper.h
+++ b/src/lua_helper.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #pragma once
 #include <chrono>
 #include <ctime>
@@ -36,4 +42,3 @@ private:
 	std::chrono::system_clock::time_point last_flight_loop_call;
 	LuaHelper();
 };
-

--- a/src/message_window.cpp
+++ b/src/message_window.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "message_window.h"
 
 int dummy_mouse_handler(

--- a/src/message_window.h
+++ b/src/message_window.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #pragma once
 #include <list>
 #include <string>

--- a/src/multi_purpose_display.cpp
+++ b/src/multi_purpose_display.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include <limits>
 #include "multi_purpose_display.h"
 #include "lua_helper.h"

--- a/src/multi_purpose_display.h
+++ b/src/multi_purpose_display.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #pragma once
 #include <string>
 #include <map>
@@ -34,4 +40,3 @@ private:
 	std::mutex guard;
 	bool turn_off;
 };
-

--- a/src/trigger.cpp
+++ b/src/trigger.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include <limits>
 #include "trigger.h"
 #include "lua_helper.h"

--- a/src/trigger.h
+++ b/src/trigger.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #pragma once
 #include <string>
 #include <queue>

--- a/src/xpanel.cpp
+++ b/src/xpanel.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "XPLMDisplay.h"
 #include <vector>
 #include <thread>

--- a/test/mock_hid_api.cpp
+++ b/test/mock_hid_api.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #pragma once
 #include"hidapi.h"
 #include <map>

--- a/test/mock_xplane.cpp
+++ b/test/mock_xplane.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "XPLMGraphics.h"
 #include "XPLMPlanes.h"
 #include "XPLMPlugin.h"

--- a/test/mock_xplane_display.cpp
+++ b/test/mock_xplane_display.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "XPLMGraphics.h"
 #include "XPLMPlanes.h"
 #include "XPLMDisplay.h"

--- a/test/test-arduino-home.ini
+++ b/test/test-arduino-home.ini
@@ -2,6 +2,8 @@
 ;
 ; Copyright (C) 2022  Norbert Takacs <norberttak@gmail.com>
 ;
+; SPDX-License-Identifier: GPL-3.0-or-later
+;
 ; This program is free software: you can redistribute it and/or modify
 ; it under the terms of the GNU General Public License as published by
 ; the Free Software Foundation, either version 3 of the License, or

--- a/test/test_arduino_home.cpp
+++ b/test/test_arduino_home.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "XPLMDefs.h"
 #include "XPLMGraphics.h"
 #include "XPLMPlugin.h"

--- a/test/test_config_parser.cpp
+++ b/test/test_config_parser.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "XPLMDefs.h"
 #include "XPLMGraphics.h"
 #include "XPLMPlugin.h"

--- a/test/test_dynamic_speed.cpp
+++ b/test/test_dynamic_speed.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "XPLMDefs.h"
 #include "XPLMGraphics.h"
 #include "XPLMPlugin.h"

--- a/test/test_generic_display.cpp
+++ b/test/test_generic_display.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "XPLMDefs.h"
 #include "XPLMGraphics.h"
 #include "XPLMPlugin.h"

--- a/test/test_lua.cpp
+++ b/test/test_lua.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "XPLMDefs.h"
 #include "XPLMGraphics.h"
 #include "XPLMPlugin.h"

--- a/test/test_multi_panel.cpp
+++ b/test/test_multi_panel.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "XPLMDefs.h"
 #include "XPLMGraphics.h"
 #include "XPLMPlugin.h"

--- a/test/test_radio_panel.cpp
+++ b/test/test_radio_panel.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "XPLMDefs.h"
 #include "XPLMGraphics.h"
 #include "XPLMPlugin.h"

--- a/test/test_xpanel_plugin.cpp
+++ b/test/test_xpanel_plugin.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include <filesystem>
 #include "XPLMDefs.h"
 #include "XPLMGraphics.h"

--- a/test/xpanel.ini
+++ b/test/xpanel.ini
@@ -1,5 +1,7 @@
 ; Copyright (C) 2022  Norbert Takacs <norberttak@gmail.com>
 ;
+; SPDX-License-Identifier: GPL-3.0-or-later
+;
 ; This program is free software: you can redistribute it and/or modify
 ; it under the terms of the GNU General Public License as published by
 ; the Free Software Foundation, either version 3 of the License, or


### PR DESCRIPTION
SPDX-License-Identifier is a standard format for communicating FOSS
license information in a simple, efficient, portable, and machine-readable
manner.

https://spdx.dev/

It is widely adopted by open-source projects, for example:
https://lwn.net/Articles/739183/

Fixes #9