### PR TITLE
Disable hidapi error reporting on Windows

### DIFF
--- a/XPanel.vcxproj
+++ b/XPanel.vcxproj
@@ -123,7 +123,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>WINVER=0x0601;_CRT_SECURE_NO_WARNINGS=1;_WIN32_WINNT=0x0601;_WIN32_WINDOWS=0x0601;WIN32;_DEBUG;_WINDOWS;_USRDLL;SIMDATA_EXPORTS;IBM=1;XPLM200=1;XPLM210=1;XPLM300=1;XPLM301=1;XPLM302=1;PLUGIN_SIGNATURE="xpanel";PLUGIN_VERSION="1.2";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_WINDOWS=0x0601;WIN32;_DEBUG;_WINDOWS;_USRDLL;SIMDATA_EXPORTS;IBM=1;XPLM200=1;XPLM210=1;XPLM300=1;XPLM301=1;XPLM302=1;PLUGIN_SIGNATURE="xpanel";PLUGIN_VERSION="1.2";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)\hidapi\headers;$(SolutionDir)\LUA\include;$(SolutionDir)\SDK\CHeaders\XPLM;$(SolutionDir)\SDK\CHeaders\Widgets;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
@@ -145,7 +145,7 @@
       </FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS=1;IBM=1;XPLM200=1;XPLM210=1;XPLM300=1;XPLM301=1;XPLM302=1;PLUGIN_SIGNATURE="xpanel";PLUGIN_VERSION="1.2";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;IBM=1;XPLM200=1;XPLM210=1;XPLM300=1;XPLM301=1;XPLM302=1;PLUGIN_SIGNATURE="xpanel";PLUGIN_VERSION="1.2";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalIncludeDirectories>$(SolutionDir)\hidapi\headers;$(SolutionDir)\LUA\include;$(SolutionDir)\SDK\CHeaders\XPLM;$(SolutionDir)\SDK\CHeaders\Widgets;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/src/UsbHidDevice.cpp
+++ b/src/UsbHidDevice.cpp
@@ -426,7 +426,13 @@ void UsbHidDevice::release()
 
 std::string UsbHidDevice::hidapi_error(hid_device *dev)
 {
+	const wchar_t* hid_err = hid_error(dev);
+	if (!hid_err)
+		return "no error";
+
 	char error_msg[256];
-	std::wcstombs(error_msg, hid_error(dev), 256);
-	return std::string(error_msg);
+	if (std::wcstombs(error_msg, hid_err, 256) == static_cast<std::size_t>(-1))
+		return "could not render error message";
+
+	return error_msg;
 }

--- a/src/UsbHidDevice.cpp
+++ b/src/UsbHidDevice.cpp
@@ -426,6 +426,9 @@ void UsbHidDevice::release()
 
 std::string UsbHidDevice::hidapi_error(hid_device *dev)
 {
+#if defined(_WIN32)
+	return "unknown";
+#else
 	const wchar_t* hid_err = hid_error(dev);
 	if (!hid_err)
 		return "no error";
@@ -435,4 +438,5 @@ std::string UsbHidDevice::hidapi_error(hid_device *dev)
 		return "could not render error message";
 
 	return error_msg;
+#endif
 }

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -96,7 +96,7 @@
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)src;$(SolutionDir)hidapi\headers;$(SolutionDir)LUA\include;$(SolutionDir)SDK\CHeaders\XPLM;$(SolutionDir)SDK\CHeaders\Widgets;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WINVER=0x0601;_CRT_SECURE_NO_WARNINGS=1;_WIN32_WINNT=0x0601;_WIN32_WINDOWS=0x0601;WIN32;_DEBUG;_WINDOWS;_USRDLL;SIMDATA_EXPORTS;IBM=1;XPLM200=1;XPLM210=1;XPLM300=1;XPLM301=1;XPLM302=1;XPLM303=1;PLUGIN_SIGNATURE="xpanel";PLUGIN_VERSION="1.2";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_WINDOWS=0x0601;WIN32;_DEBUG;_WINDOWS;_USRDLL;SIMDATA_EXPORTS;IBM=1;XPLM200=1;XPLM210=1;XPLM300=1;XPLM301=1;XPLM302=1;XPLM303=1;PLUGIN_SIGNATURE="xpanel";PLUGIN_VERSION="1.2";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp17</LanguageStandard>
@@ -157,7 +157,7 @@ xcopy /y /d "$(SolutionDir)config\board-config.ini" "$(OutDir)"
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>false</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)src;$(SolutionDir)hidapi\headers;$(SolutionDir)LUA\include;$(SolutionDir)SDK\CHeaders\XPLM;$(SolutionDir)SDK\CHeaders\Widgets;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WINVER=0x0601;_CRT_SECURE_NO_WARNINGS=1;_WIN32_WINNT=0x0601;_WIN32_WINDOWS=0x0601;WIN32;_WINDOWS;_USRDLL;SIMDATA_EXPORTS;IBM=1;XPLM200=1;XPLM210=1;XPLM300=1;XPLM301=1;XPLM302=1;XPLM303=1;NDEBUG;PLUGIN_SIGNATURE="xpanel";PLUGIN_VERSION="1.2";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_WINDOWS=0x0601;WIN32;_WINDOWS;_USRDLL;SIMDATA_EXPORTS;IBM=1;XPLM200=1;XPLM210=1;XPLM300=1;XPLM301=1;XPLM302=1;XPLM303=1;NDEBUG;PLUGIN_SIGNATURE="xpanel";PLUGIN_VERSION="1.2";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp17</LanguageStandard>


### PR DESCRIPTION
`hid_error()` currently crashes on Windows.