### PR TITLE
ci/release: install dependencies on Linux

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-20.04, windows-latest]
 
     name: Build and Test (CMake, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -59,10 +59,11 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install dependencies
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-20.04'
         run: |
           sudo apt-get update -qq && sudo apt-get install -y build-essential cmake liblua5.3-dev libhidapi-dev
           echo 'XPANEL_INSTALL_DEPS_FLAG=-DINSTALL_DEPS=ON' >> $GITHUB_ENV
+
 
       - name: Build
         run: |
@@ -75,8 +76,8 @@ jobs:
       - name: Install
         run: cmake --build build --target install
 
-      - name: Upload built plugin (Linux)
-        if: matrix.os == 'ubuntu-latest'
+      - name: Upload built plugin (Linux glibc 2.31)
+        if: matrix.os == 'ubuntu-20.04'
         uses: actions/upload-artifact@v3
         with:
           name: built-plugin-linux

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -60,11 +60,13 @@ jobs:
 
       - name: Install dependencies
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update -qq && sudo apt-get install -y build-essential cmake liblua5.3-dev libhidapi-dev
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y build-essential cmake liblua5.3-dev libhidapi-dev
+          echo 'XPANEL_INSTALL_DEPS_FLAG=-DINSTALL_DEPS=ON' >> $GITHUB_ENV
 
       - name: Build
         run: |
-          cmake -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install" -S . -B build
+          cmake -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install" -S . -B build ${XPANEL_INSTALL_DEPS_FLAG}
           cmake --build build
 
       - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TAG: v${{ inputs.release-version }}
       WINDOWS_RELEASE_PLUGIN_ZIP: xpanel_windows_v${{ inputs.release-version }}.zip
-      LINUX_RELEASE_PLUGIN_ZIP: xpanel_linux_v${{ inputs.release-version }}.zip
+      LINUX_RELEASE_PLUGIN_ZIP: xpanel_linux_v${{ inputs.release-version }}_glibc2.31.zip
       SAMPLE_CONFIG_ZIP: sample_configs_v${{ inputs.release-version }}.zip
 
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ set(PLUGIN_INSTALL_DIR ${PROJECT_NAME}/64)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/.cmake)
 
+option(INSTALL_DEPS "Install dependencies into the plugin's directory" OFF)
+
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set(CMAKE_CXX_STANDARD 20 CACHE STRING "C++ standard")
 set(CMAKE_CXX_STANDARD_REQUIRED ON CACHE BOOL "C++ standard is a requirement")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,4 +36,12 @@ endif()
 
 set_target_properties(xpanel PROPERTIES PREFIX "" OUTPUT_NAME ${XPANEL_PLUGIN_FILENAME} SUFFIX ".xpl")
 
-install(TARGETS xpanel DESTINATION ${PLUGIN_INSTALL_DIR})
+if (INSTALL_DEPS)
+    set_target_properties(xpanel PROPERTIES INSTALL_RPATH "\$ORIGIN")
+    install(TARGETS xpanel
+        RUNTIME_DEPENDENCIES POST_EXCLUDE_REGEXES "lib(c|gcc_s|m|stdc|stdc\\+\\+|atomic|rt|dl|pthread)\\." "ld-linux"
+        DESTINATION ${PLUGIN_INSTALL_DIR}
+    )
+else()
+    install(TARGETS xpanel DESTINATION ${PLUGIN_INSTALL_DIR})
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,8 +34,6 @@ elseif (UNIX)
     set(XPANEL_PLUGIN_FILENAME "lin")
 endif()
 
-set_target_properties(xpanel PROPERTIES PREFIX "")
-set_target_properties(xpanel PROPERTIES OUTPUT_NAME ${XPANEL_PLUGIN_FILENAME})
-set_target_properties(xpanel PROPERTIES SUFFIX ".xpl")
+set_target_properties(xpanel PROPERTIES PREFIX "" OUTPUT_NAME ${XPANEL_PLUGIN_FILENAME} SUFFIX ".xpl")
 
 install(TARGETS xpanel DESTINATION ${PLUGIN_INSTALL_DIR})


### PR DESCRIPTION
This adds Linux dependencies to the release binary, and also clarifies that these binaries are for glibc 2.31 or higher.

Static linking would have been better, but Ubuntu does not provide fPIC static libraries for Lua, so I ended up implementing this terrible dependency installation method.