### PR TITLE
Add Saitek switch panel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@ This is a plugin for [X-Plane](https://www.x-plane.com/) >=11 flight simulator. 
 
 It has a configuration file where you can define the logical connections between hardware elements (buttons, switches, displays, etc) and the internal [dataref](https://developer.x-plane.com/sdk/) of X-Plane.
 
-Currently, it supports four types of USB devices:
+Currently, it supports the bellow types of USB-HID devices:
 
 1. [Saitek Multi Panel](https://www.saitek.com/uk/prod-bak/multi.html) This is a device that mainly contains the buttons associated with the autopilot functions
 2. [Saitek Radio Panel](https://www.saitek.com/uk/prod-bak/radio.html) Device to conrol radio functions of your airplane
-3. [Logitech/Saitek Flight Instrument Panel](https://www.saitek.com/uk/prod-bak/fip.html) Device with a graphical screen to display aircraft instruments (supported only on Windows)
-4. Arduino based USB HID device which can simulate switches and displays customized on your own.
-5. [TRC-1000 PFD/MFD & Audio Panel](https://www.simkits.com/product/trc1000-complete-glass-cockpit/) These devices is a replica of Garmin G1000 cockpit panels
+3. [Saitek Switch Panel](https://www.saitek.com/uk/prod-bak/switch.html) Device with switches
+4. [Logitech/Saitek Flight Instrument Panel](https://www.saitek.com/uk/prod-bak/fip.html) Device with a graphical screen to display aircraft instruments (supported only on Windows)
+5. Arduino based USB HID device which can simulate switches and displays customized on your own.
+6. [TRC-1000 PFD/MFD & Audio Panel](https://www.simkits.com/product/trc1000-complete-glass-cockpit/) These devices are replica of Garmin G1000 cockpit panels
 
 ## Configuration syntax
 For configuration file syntax please see the document [here](doc/configuration.md)

--- a/XPanel.vcxproj
+++ b/XPanel.vcxproj
@@ -183,6 +183,7 @@
     <ClCompile Include="src\SaitekMultiPanel.cpp" />
     <ClCompile Include="src\MessageWindow.cpp" />
     <ClCompile Include="src\TRC1000.cpp" />
+    <ClCompile Include="src\SaitekSwitchPanel.cpp" />
     <ClCompile Include="src\XPanel.cpp" />
     <ClCompile Include="src\UsbHidDevice.cpp" />
     <ClCompile Include="src\Trigger.cpp" />
@@ -213,6 +214,7 @@
     <ClInclude Include="src\Device.h" />
     <ClInclude Include="src\ConfigParser.h" />
     <ClInclude Include="src\SaitekMultiPanel.h" />
+    <ClInclude Include="src\SaitekSwitchPanel.h" />
     <ClInclude Include="src\UsbHidDevice.h" />
     <ClInclude Include="src\Trigger.h" />
     <ClInclude Include="src\TRC1000PFD.h" />

--- a/XPanel.vcxproj.filters
+++ b/XPanel.vcxproj.filters
@@ -94,6 +94,8 @@
     </ClCompile>
     <ClCompile Include="src\TRC1000Audio.cpp">
       <Filter>Source Files</Filter>
+    <ClCompile Include="src\SaitekSwitchPanel.cpp">
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -164,6 +166,8 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\TRC1000Audio.h">
+      <Filter>Header Files</Filter>
+    <ClInclude Include="src\SaitekSwitchPanel.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -116,6 +116,41 @@ Every button shall be defined as a new section and need to have a pre-defined id
 |RADIO_DISPLAY_STBY_DOWN | Down Standby Display (7 segments, 5 digits)
 |RADIO_DISPLAY_ACTIVE_DOWN | Down Active Display (7 segments, 5 digits)
 
+### Saitek Switch Panel's ids:
+| ID | Recommended Function  |
+|---|---|
+|BATTERY| Battery on/off
+|ALTERNATOR| Alternator on/off
+|AVIONICS| Avionics power switch
+|FUEL_PUMP| Fuel pump
+|DE_ICE| De-ice (wing, engine, etc...)
+|PITOT_HEAT| Pitot heat
+|COWL_FLAPS| Cowl flaps open/close
+|PANEL_LIGHTS| Panel lights
+|BEACON| beacon light
+|NAV| nav light
+|STROBE| Strobe light
+|TAXI| taxi light
+|LANDING| Landing light
+|MAG_OFF| Magneto (ignition) off
+|MAG_RIGHT| Magneto (ignition) right side
+|MAG_LEFT| Magneto (ignition) left side
+|MAG_BOTH| Magneto (ignition) both side
+|ENG_START| Engine starter
+|GEAR_UP| Landing gear up
+|GEAR_DOWN| Landing gear down
+
+| LED ID | Recommended Function  |
+|---|---|
+|GEAR_NOSE_GREEN| Landing gear nose, green light
+|GEAR_LEFT_GREEN| Landing gear left, green light
+|GEAR_RIGHT_GREEN| Landing gear right, green light
+|GEAR_NOSE_RED| Landing gear nose, red light
+|GEAR_LEFT_RED| Landing gear left, red light
+|GEAR_RIGHT_RED| Landing gear right, red light
+
+Please note the device has only 3 LEDs. They are multi-color devices. Can lit in green/red/yellow colors as well.
+If you want to lit in yellow, please turn on both green and red colors.
 ### TRC-1000 PFD/MFD device's button/encoder ids:
 | Button ID | Recommended Function  |
 |---|---|

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(xpanel SHARED
     MultiPurposeDisplay.cpp
     SaitekMultiPanel.cpp
     SaitekRadioPanel.cpp
+    SaitekSwitchPanel.cpp
     Trigger.cpp
     UsbHidDevice.cpp
     XPanel.cpp

--- a/src/SaitekSwitchPanel.cpp
+++ b/src/SaitekSwitchPanel.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <cstring>
+#include <cstdlib>
+#include "UsbHidDevice.h"
+#include "SaitekSwitchPanel.h"
+#include "Logger.h"
+
+#define WRITE_BUFFER_SIZE 2
+#define READ_BUFFER_SIZE 4
+
+SaitekSwitchPanel::SaitekSwitchPanel(DeviceConfiguration& config) :UsbHidDevice(config, READ_BUFFER_SIZE, WRITE_BUFFER_SIZE)
+{
+	// push buttons
+	switch_buttons.push_back(PanelButton((0 * 8) + 0, "BATTERY"));
+	switch_buttons.push_back(PanelButton((0 * 8) + 1, "ALTERNATOR"));
+	switch_buttons.push_back(PanelButton((0 * 8) + 2, "AVIONICS"));
+	switch_buttons.push_back(PanelButton((0 * 8) + 3, "FUEL_PUMP"));
+	switch_buttons.push_back(PanelButton((0 * 8) + 4, "DE_ICE"));
+	switch_buttons.push_back(PanelButton((0 * 8) + 5, "PITOT_HEAT"));
+	switch_buttons.push_back(PanelButton((0 * 8) + 6, "COWL_FLAPS"));
+	switch_buttons.push_back(PanelButton((0 * 8) + 7, "PANEL_LIGHTS"));
+
+	switch_buttons.push_back(PanelButton((1 * 8) + 0, "BEACON"));
+	switch_buttons.push_back(PanelButton((1 * 8) + 1, "NAV"));
+	switch_buttons.push_back(PanelButton((1 * 8) + 2, "STROBE"));
+	switch_buttons.push_back(PanelButton((1 * 8) + 3, "TAXI"));
+	switch_buttons.push_back(PanelButton((1 * 8) + 4, "LANDING"));
+	switch_buttons.push_back(PanelButton((1 * 8) + 5, "MAG_OFF"));
+	switch_buttons.push_back(PanelButton((1 * 8) + 6, "MAG_RIGHT"));
+	switch_buttons.push_back(PanelButton((1 * 8) + 7, "MAG_LEFT"));
+
+	switch_buttons.push_back(PanelButton((2 * 8) + 0, "MAG_BOTH"));
+	switch_buttons.push_back(PanelButton((2 * 8) + 1, "ENG_START"));
+	switch_buttons.push_back(PanelButton((2 * 8) + 2, "GEAR_UP"));
+	switch_buttons.push_back(PanelButton((2 * 8) + 3, "GEAR_DOWN"));
+
+	register_buttons(switch_buttons);
+
+	switch_lights.push_back(PanelLight((1 * 8) + 0, "GEAR_NOSE_GREEN"));
+	switch_lights.push_back(PanelLight((1 * 8) + 1, "GEAR_LEFT_GREEN"));
+	switch_lights.push_back(PanelLight((1 * 8) + 2, "GEAR_RIGHT_GREEN"));
+
+	switch_lights.push_back(PanelLight((1 * 8) + 3, "GEAR_NOSE_RED"));
+	switch_lights.push_back(PanelLight((1 * 8) + 4, "GEAR_LEFT_RED"));
+	switch_lights.push_back(PanelLight((1 * 8) + 5, "GEAR_RIGHT_RED"));
+	/* Yellow color lights can be turned on by issuing green + red */
+
+	register_lights(switch_lights);
+}
+
+int SaitekSwitchPanel::connect()
+{
+	unsigned char buff[WRITE_BUFFER_SIZE];
+	if (UsbHidDevice::connect() != EXIT_SUCCESS)
+	{
+		Logger(TLogLevel::logERROR) << "SaitekSwitchPanel connect. Error during connect" << std::endl;
+		return EXIT_FAILURE;
+	}
+
+	memset(buff, 0, sizeof(buff)); // clear all LED lights
+	if (write_device(buff, sizeof(buff)) != EXIT_SUCCESS)
+	{
+		Logger(TLogLevel::logERROR) << "SaitekSwitchPanel connect. error in write_device" << std::endl;
+		return EXIT_FAILURE;
+	}
+
+	Logger(TLogLevel::logDEBUG) << "SaitekSwitchPanel connect. successful" << std::endl;
+	return EXIT_SUCCESS;
+}
+
+void SaitekSwitchPanel::start()
+{
+	Logger(TLogLevel::logDEBUG) << "SaitekSwitchPanel::start called" << std::endl;
+	UsbHidDevice::start();
+}
+
+void SaitekSwitchPanel::stop(int timeout)
+{
+	Logger(TLogLevel::logDEBUG) << "SaitekSwitchPanel::stop called" << std::endl;
+
+	// Blank LED lights before exit
+	unsigned char buff[WRITE_BUFFER_SIZE];
+	memset(buff, 0, sizeof(buff)); // clear all LED lights
+	if (write_device(buff, sizeof(buff)) != EXIT_SUCCESS)
+	{
+		Logger(TLogLevel::logERROR) << "SaitekSwitchPanel stop. error in write_device" << std::endl;
+		return;
+	}
+
+	UsbHidDevice::stop(timeout);
+}

--- a/src/SaitekSwitchPanel.h
+++ b/src/SaitekSwitchPanel.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 Norbert Takacs
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+#include <vector>
+#include "Device.h"
+#include "UsbHidDevice.h"
+#include "Configuration.h"
+
+class SaitekSwitchPanel : public UsbHidDevice
+{
+private:
+	std::vector<PanelButton> switch_buttons;
+	std::vector<PanelLight> switch_lights;
+public:
+	SaitekSwitchPanel(DeviceConfiguration& config);
+	int connect();
+	void start();
+	void stop(int timeout);
+};

--- a/src/XPanel.cpp
+++ b/src/XPanel.cpp
@@ -21,6 +21,7 @@
 #include "UsbHidDevice.h"
 #include "SaitekMultiPanel.h"
 #include "SaitekRadioPanel.h"
+#include "SaitekSwitchPanel.h"
 #include "ArduinoHomeCockpit.h"
 #include "Configuration.h"
 #include "ConfigParser.h"
@@ -304,6 +305,20 @@ int init_and_start_xpanel_plugin(void)
 			device->connect();
 			device->start();
 			device->thread_handle = new std::thread(&SaitekRadioPanel::thread_func, (SaitekRadioPanel*)device);
+			LuaHelper::get_instace()->register_hid_device((UsbHidDevice*)device);
+			break;
+		case DeviceType::SAITEK_SWITCH:
+			// set default vid & pid if it's not set in config file
+			if (it.vid == 0)
+				it.vid = 0x06a3;
+			if (it.pid == 0)
+				it.pid = 0x0d67;
+			Logger(TLogLevel::logDEBUG) << "add new saitek switch panel device" << std::endl;
+			device = new SaitekSwitchPanel(it);
+			devices.push_back(device);
+			device->connect();
+			device->start();
+			device->thread_handle = new std::thread(&SaitekSwitchPanel::thread_func, (SaitekSwitchPanel*)device);
 			LuaHelper::get_instace()->register_hid_device((UsbHidDevice*)device);
 			break;
 		case DeviceType::LOGITECH_FIP:

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -204,6 +204,7 @@ xcopy /y /d /S /I "$(SolutionDir)test\fip-images\*" "$(OutDir)\fip-images"
     <ClCompile Include="..\src\TRC1000.cpp" />
     <ClCompile Include="..\src\TRC1000Audio.cpp" />
     <ClCompile Include="..\src\TRC1000PFD.cpp" />
+    <ClCompile Include="..\src\SaitekSwitchPanel.cpp" />
     <ClCompile Include="..\src\Trigger.cpp" />
     <ClCompile Include="..\src\UsbHidDevice.cpp" />
     <ClCompile Include="..\src\XPanel.cpp" />

--- a/test/test.vcxproj.filters
+++ b/test/test.vcxproj.filters
@@ -128,6 +128,9 @@
     </ClCompile>
     <ClCompile Include="test_trc1000_audio.cpp">
       <Filter>Source Files</Filter>
+    </ClCompile>    
+    <ClCompile Include="..\src\SaitekSwitchPanel.cpp">
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR is about the support of the missing third Saitek device: The switch panel.
https://www.saitek.com/uk/prod/switch.html

The biggest part of the code is shared with other HID devices so this is mainly about the config options.

- [x] Documentation
- [x] Cmake files