### PR TITLE
FIP: remove not needed debug messages

### DIFF
--- a/src/FIPDriver.cpp
+++ b/src/FIPDriver.cpp
@@ -276,7 +276,7 @@ uint16_t fip_get_button_states(FIP_device_handle* device)
 	}
 	guard.unlock();
 
-	Logger(logTRACE) << "FIP driver: fip_get_button_state serial=" << device->serial_number << " state:" << states << std::endl;
+	//Logger(logTRACE) << "FIP driver: fip_get_button_state serial=" << device->serial_number << " state:" << states << std::endl;
 	return states;
 }
 

--- a/src/FIPScreen.cpp
+++ b/src/FIPScreen.cpp
@@ -52,7 +52,7 @@ void FIPScreen::evaluate_and_store_screen_action()
 
 		action->value_old = action_value;
 
-		Logger(logTRACE) << "FIP screen: value changed (page " << action->page_index << " layer " << action->layer_index << "): " << action_value << std::endl;
+		//Logger(logTRACE) << "FIP screen: value changed (page " << action->page_index << " layer " << action->layer_index << "): " << action_value << std::endl;
 
 		guard.lock();
 		switch (action->type) {


### PR DESCRIPTION
Fix #53: Remove the unnecessary debug messages that flood the xplane log file.
Signed-off-by: Norbert Takacs <norberttak@gmail.com>