### PR TITLE
Disable lua on error

### DIFF
--- a/src/Action.cpp
+++ b/src/Action.cpp
@@ -255,9 +255,8 @@ void Action::activate()
 	//do a lua script
 	if (!lua_str.empty())
 	{
-		Logger(TLogLevel::logTRACE) << "activate lua action: " << lua_str << std::endl;
-		if (LuaHelper::get_instace()->do_string(lua_str) == EXIT_FAILURE)
-			Logger(TLogLevel::logERROR) << "Error while execute lua string: " << lua_str << std::endl;
+		Logger(TLogLevel::logTRACE) << "activate lua action: " << lua_str << std::endl;;
+		LuaHelper::get_instace()->do_string(lua_str);
 	}
 }
 

--- a/src/FIPScreen.cpp
+++ b/src/FIPScreen.cpp
@@ -35,7 +35,9 @@ void FIPScreen::evaluate_and_store_screen_action()
 		}
 		else if (action->lua_str != "")
 		{
-			action_value = (int)LuaHelper::get_instace()->do_string("return " + action->lua_str);
+			double ret_value=0;
+			LuaHelper::get_instace()->do_string("return " + action->lua_str, ret_value);
+			action_value = (int)ret_value;
 		}
 		else if (action->constant_val != 0)
 		{

--- a/src/GenericDisplay.cpp
+++ b/src/GenericDisplay.cpp
@@ -85,7 +85,7 @@ void GenericDisplay::evaluate_and_store_dataref_value()
 		if (const_value > DBL_MIN)
 			display_value = const_value;
 		else if (!lua_function.empty())
-			display_value = LuaHelper::get_instace()->do_string("return " + lua_function);
+			LuaHelper::get_instace()->do_string("return " + lua_function, display_value);
 		break;
 	}
 	guard.unlock();

--- a/src/LuaHelper.h
+++ b/src/LuaHelper.h
@@ -25,7 +25,8 @@ public:
 	void push_global_string(std::string name, std::string value);
 	int load_script_file(std::string file_name);
 	int do_flight_loop();
-	double do_string(std::string lua_str);
+	int do_string(std::string lua_str, double& ret_value);
+	int do_string(std::string lua_str);
 	XPLMCommandRef get_commandref(std::string commandref_str);
 	XPLMDataRef get_dataref(std::string dataref_str);
 	XPLMDataTypeID get_dataref_type(XPLMDataRef dataref);
@@ -39,6 +40,7 @@ private:
 	std::map<XPLMDataRef, XPLMDataTypeID> data_ref_types;
 	std::vector<UsbHidDevice*> hid_devices;
 	bool flight_loop_defined;
+	bool lua_enabled;
 	std::chrono::system_clock::time_point last_flight_loop_call;
 	LuaHelper();
 };

--- a/src/Trigger.cpp
+++ b/src/Trigger.cpp
@@ -53,7 +53,7 @@ void Trigger::evaluate_and_store_action()
 	}
 	else
 	{
-		act_value = LuaHelper::get_instace()->do_string("return " + lua_str);
+		LuaHelper::get_instace()->do_string("return " + lua_str,act_value);
 	}
 
 	guard.lock();

--- a/test/test_lua.cpp
+++ b/test/test_lua.cpp
@@ -34,7 +34,7 @@ namespace test
 
 		TEST_METHOD(TestLuaDoString)
 		{
-			LuaHelper::get_instace()->do_string("command_once(\"/sim/test\")");			
+			LuaHelper::get_instace()->do_string("command_once(\"/sim/test\")");
 			Assert::AreEqual("/sim/test_ONCE", test_get_last_command().c_str());
 
 			LuaHelper::get_instace()->do_string("command_begin(\"/sim/test\")");

--- a/test/test_multi_panel.cpp
+++ b/test/test_multi_panel.cpp
@@ -255,14 +255,17 @@ namespace test
 			test_hid_set_read_data(buffer, sizeof(buffer));
 			std::this_thread::sleep_for(150ms);
 			test_flight_loop(config.device_configs);
-			Assert::AreEqual(1, (int)LuaHelper::get_instace()->do_string("return get_hid_input_status('REV')"));
+			double ret_value=0;
+			LuaHelper::get_instace()->do_string("return get_hid_input_status('REV')", ret_value);
+			Assert::AreEqual(1, (int)ret_value);
 			
 			// Release REV button
 			buffer[1] = 0;
 			test_hid_set_read_data(buffer, sizeof(buffer));
 			std::this_thread::sleep_for(150ms);
 			test_flight_loop(config.device_configs);
-			Assert::AreEqual(0, (int)LuaHelper::get_instace()->do_string("return get_hid_input_status('REV')"));
+			LuaHelper::get_instace()->do_string("return get_hid_input_status('REV')", ret_value);
+			Assert::AreEqual(0, (int)ret_value);
 		}
 
 		TEST_METHOD_CLEANUP(TestMultiPanelCleanup)


### PR DESCRIPTION
If an error happens in the LUA subsystem we need to disable it to be safe.
In that way, we prevent flooding error messages and unexpected crashes due to the LUA interpreter
A plugin reload will initialize the LUA subsystem again.