### PR TITLE
Parser refactor

### DIFF
--- a/XPanel.vcxproj
+++ b/XPanel.vcxproj
@@ -174,6 +174,7 @@
     <ClCompile Include="src\FIPDriver.cpp" />
     <ClCompile Include="src\FIPPage.cpp" />
     <ClCompile Include="src\FIPScreen.cpp" />
+    <ClCompile Include="src\IniFileParser.cpp" />
     <ClCompile Include="src\SaitekRadioPanel.cpp" />
     <ClCompile Include="src\LuaHelper.cpp" />
     <ClCompile Include="src\MultiPurposeDisplay.cpp" />
@@ -210,6 +211,7 @@
     <ClInclude Include="src\FIPDriver.h" />
     <ClInclude Include="src\FIPPage.h" />
     <ClInclude Include="src\FIPScreen.h" />
+    <ClInclude Include="src\IniFileParser.h" />
     <ClInclude Include="src\SaitekRadioPanel.h" />
     <ClInclude Include="src\LuaHelper.h" />
     <ClInclude Include="src\MessageWindow.h" />

--- a/XPanel.vcxproj.filters
+++ b/XPanel.vcxproj.filters
@@ -29,6 +29,7 @@
     <ClCompile Include="src\FIPLayer.cpp" />
     <ClCompile Include="src\FIPImageLayer.cpp" />
     <ClCompile Include="src\FIPTextLayer.cpp" />
+    <ClCompile Include="src\IniFileParser.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\GenericDisplay.h" />
@@ -59,6 +60,7 @@
     <ClInclude Include="src\FIPImageLayer.h" />
     <ClInclude Include="src\FIPTextLayer.h" />
     <ClInclude Include="src\FIPFonts.h" />
+    <ClInclude Include="src\IniFileParser.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="config\device-generic.ini" />

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -612,12 +612,12 @@ serial="YOUR_DEVICE_SERIAL"
 
     [screen:id="fip-screen"]
     [page:id="ADF"]
-        [layer:image="fip-images/Adf_Kompass_Ring.bmp,ref_x:120,ref_y:120,base_rot=0"]
+        [layer:image="fip-images/Adf_Kompass_Ring.bmp,ref_x:120,ref_y:120,base_rot:0"]
         offset_x="const:200"
         offset_y="const:120"
         rotation="dataref:sim/cockpit/radios/adf1_cardinal_dir,scale:-1"
 
-        [layer:image="fip-images/adf_needle.bmp,ref_x:90,ref_y:8,base_rot=-90"]
+        [layer:image="fip-images/adf_needle.bmp,ref_x:90,ref_y:8,base_rot:-90"]
         offset_x="const:200"
         offset_y="const:120"
         rotation="dataref:sim/cockpit2/radios/indicators/adf1_relative_bearing_deg,scale:1"
@@ -627,7 +627,21 @@ You can select the most convenient reference point which allows you to use to ei
 
 For your convenience, the layer can have a base rotation value. This means that even if the BMP file is created with a different
 orientation you can rotate it according to your purposes. Further rotation is allowed on the layer but the
-rotation angle=0 will be the position defined by the base_rot property.
+rotation angle:0 will be the position defined by the base_rot property.
+
+**Warning**
+Starting with **v1.8** there is a small change in the FIP layer definition: the base_rot value separator now (in accordance with every other options) is a ':' and not an '=' as in previous version. Please update your config files.
+
+Old format:
+```ini
+[layer:image="fip-images/Adf_Kompass_Ring.bmp,ref_x:120,ref_y:120,base_rot=0"]
+```
+
+New format:
+```ini
+[layer:image="fip-images/Adf_Kompass_Ring.bmp,ref_x:120,ref_y:120,base_rot:0"]
+```
+
 
 A layer can be moved in two different ways: translation and rotation.
 
@@ -658,7 +672,7 @@ You can define a mask for a layer. This means that only a part of the layer imag
 so in the configuration file, you should define this:
 ```ini
         [page:id="TEST_MASK"]
-            [layer:image="fip-images/bmp_test_big_image.bmp,ref_x:0,ref_y:157,base_rot=0"]
+            [layer:image="fip-images/bmp_test_big_image.bmp,ref_x:0,ref_y:157,base_rot:0"]
             mask="screen_x:0,screen_y:120,height:100,width:60"
 ```
 With the above config only those parts of the layer image will be displayed that are inside the defined mask window.
@@ -739,7 +753,7 @@ If you put for example -1.5 it will rotate x1.5 speed.
 
 ```ini
 [page:id="ADF"]
-    [layer:image="fip-images/Adf_Kompass_Ring.bmp,ref_x:120,ref_y:120,base_rot=0"]
+    [layer:image="fip-images/Adf_Kompass_Ring.bmp,ref_x:120,ref_y:120,base_rot:0"]
     offset_x="const:200"
     offset_y="const:120"
     rotation="dataref:sim/cockpit/radios/adf1_cardinal_dir,scale:-1"
@@ -759,7 +773,7 @@ we put the ring scale image previously.
 The rotation of the needle (on this default C172 aircraft) shall be connected to the adf1_relative_bearing_deg dataref
 
 ```ini
-    [layer:image="fip-images/adf_needle.bmp,ref_x:90,ref_y:8,base_rot=-90"]
+    [layer:image="fip-images/adf_needle.bmp,ref_x:90,ref_y:8,base_rot:-90"]
     offset_x="const:200"
     offset_y="const:120"
     rotation="dataref:sim/cockpit2/radios/indicators/adf1_relative_bearing_deg,scale:1"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(xpanel SHARED
     Action.cpp
     AgeingCounter.cpp
     ArduinoHomeCockpit.cpp
+    IniFileParser.cpp
     ConfigParser.cpp
     Configuration.cpp
     Device.cpp

--- a/src/ConfigParser.h
+++ b/src/ConfigParser.h
@@ -8,15 +8,63 @@
 #include <string>
 #include <vector>
 #include "Configuration.h"
+#include "IniFileParser.h"
 
 class Configparser
 {
 private:
-	const std::string RE_FLOAT = "([+-]*[0-9\\.]+)";
-	const std::string RE_INT = "([+-]*[0-9]+)";
-	const std::string RE_REF = "([a-zA-Z0-9\\/_-]+)";
-	const std::string RE_TEXT = "(.+)";
-	const std::string RE_LUA = "(.+)";
+	typedef int (Configparser::* f_handle_on_key_value)(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config);
+
+	std::map<std::string, f_handle_on_key_value> process_functions;
+	std::vector<std::string> tokenize(std::string line);
+	void check_and_get_array_index(std::string& dataref, int& index);
+	int process_ini_section(IniFileSection& section, Configuration& config);
+
+	int process_fip_layer_section(IniFileSection& section, Configuration& config);
+
+	int handle_on_push_or_release(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config);
+	int handle_on_lit_or_unlit_or_blink(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config);
+	int handle_on_dynamic_speed(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config);
+	int handle_on_vid(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config);
+	int handle_on_pid(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config);
+	int handle_on_log_level(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config);
+	int handle_on_acf_file(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config);
+	int handle_on_script_file(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config);
+	int handle_on_line_add(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config);
+	int handle_on_set_bcd(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config);
+	int handle_on_encoder_inc_or_dec(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config);
+	int handle_on_fip_serial(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config);
+	int handle_on_fip_offset(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config);
+	int handle_on_fip_rotation(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config);
+	int handle_on_fip_mask(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config);
+	int handle_on_fip_text(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config);
+
+
+	const std::string TOKEN_VID = "vid";
+	const std::string TOKEN_PID = "pid";
+	const std::string TOKEN_SERIAL = "serial";
+	const std::string TOKEN_SCRIPT = "script_file";
+	const std::string TOKEN_ACF = "aircraft_acf";
+	const std::string TOKEN_LOG_LEVEL = "log_level";
+
+	const std::string TOKEN_DYN_SPEED_MID = "dynamic_speed_mid";
+	const std::string TOKEN_DYN_SPEED_HIGH = "dynamic_speed_high";
+
+	const std::string TOKEN_SECTION_DEVICE = "device";
+	const std::string TOKEN_SECTION_BUTTON = "button";
+	const std::string TOKEN_SECTION_LIGHT = "light";
+	const std::string TOKEN_SECTION_ROT_ENCODER = "encoder";
+	const std::string TOKEN_SECTION_DISPLAY = "display";
+	const std::string TOKEN_SECTION_MULTI_DISPLAY = "multi_display";
+	const std::string TOKEN_SECTION_FIP_SCREEN = "screen";
+
+	const std::string TOKEN_FIP_PAGE = "page";
+	const std::string TOKEN_FIP_LAYER = "layer";
+	const std::string TOKEN_FIP_TEXT = "text";
+	const std::string TOKEN_FIP_MASK = "mask";
+	const std::string TOKEN_FIP_OFFSET_X = "offset_x";
+	const std::string TOKEN_FIP_OFFSET_Y = "offset_y";
+	const std::string TOKEN_FIP_ROTATION = "rotation";
 
 	const std::string DEVICE_TYPE_SAITEK_MULTI = "saitek_multi";
 	const std::string DEVICE_TYPE_SAITEK_RADIO = "saitek_radio";
@@ -26,92 +74,34 @@ private:
 	const std::string DEVICE_TYPE_TRC1000PFD = "trc1000_pfd";
 	const std::string DEVICE_TYPE_TRC1000AUDIO = "trc1000_audio";
 
-	const std::string TOKEN_DEVICE  = "\\[device:id=\"([a-zA-Z0-9_-]+)\"\\]";
-	const std::string TOKEN_VID		= "vid=\"(.+)\"";
-	const std::string TOKEN_PID		= "pid=\"(.+)\"";
-	const std::string TOKEN_SERIAL  = "serial=\"(.+)\"";
-	const std::string TOKEN_SCRIPT	= "script_file=\"(.+)\"";
-	const std::string TOKEN_ACF		= "aircraft_acf=\"(.+)\"";
+	const std::string TOKEN_DATAREF = "dataref";
+	const std::string TOKEN_COMMANDREF = "commandref";
+	const std::string TOKEN_LUA = "lua";
+	const std::string TOKEN_CONST = "const";
+	const std::string TOKEN_BCD = "bcd";
+	const std::string TOKEN_ON_SELECT = "on_select";
+	const std::string TOKEN_BEGIN = "begin";
+	const std::string TOKEN_END = "end";
+	const std::string TOKEN_ON_PUSH = "on_push";
+	const std::string TOKEN_ON_RELEASE = "on_release";
+	const std::string TOKEN_LIT = "trigger_lit";
+	const std::string TOKEN_UNLIT = "trigger_unlit";
+	const std::string TOKEN_BLINK = "trigger_blink";
+	const std::string TOKEN_DISPLAY_LINE = "line";
+	const std::string TOKEN_ENCODER_INC = "on_increment";
+	const std::string TOKEN_ENCODER_DEC = "on_decrement";
+	const std::string TOKEN_IMAGE = "image";
+	const std::string TOKEN_TEXT = "text";
+	const std::string TOKEN_TYPE = "type";
 
-	// Button
-	const std::string TOKEN_BUTTON = "\\[button:id=\"([a-zA-Z0-9_-]+)\"\\]";
-	const std::string TOKEN_DYN_SPEED = "dynamic_speed_([mid|high]+)=\"" + RE_FLOAT+ "tick\\/sec:"+ RE_INT + "x\"";
-
-	const std::string TOKEN_LOG_LEVEL = "log_level=\"(.+)\"";
-	const std::string TOKEN_BUTTON_PUSH_DATAREF = "on_push=\"dataref:"+RE_REF+":"+RE_INT+"\"";
-	const std::string TOKEN_BUTTON_PUSH_DATAREF_ARRAY = "on_push=\"dataref:"+RE_REF+"\\["+RE_INT+"\\]:"+RE_INT+"\"";
-	const std::string TOKEN_BUTTON_PUSH_COMMANDREF = "on_push=\"commandref:"+RE_REF+":([begin|end|once]*)\"";
-	const std::string TOKEN_BUTTON_PUSH_LUA = "on_push=\"lua:" + RE_LUA+"\"";
-
-	const std::string TOKEN_BUTTON_RELEASE_DATAREF = "on_release=\"dataref:"+RE_REF+":"+RE_INT+"\"";
-	const std::string TOKEN_BUTTON_RELEASE_DATAREF_ARRAY = "on_release=\"dataref:"+RE_REF+"\\["+RE_INT+"\\]:"+RE_INT+"\"";
-	const std::string TOKEN_BUTTON_RELEASE_COMMANDREF = "on_release=\"commandref:"+RE_REF+":([begin|end|once]*)\"";
-	const std::string TOKEN_BUTTON_RELEASE_LUA = "on_release=\"lua:" + RE_LUA + "\"";
-
-	const std::string TOKEN_BUTTON_PUSH_DATAREF_CHANGE = "on_push=\"dataref:"+RE_REF+":"+RE_FLOAT+":"+RE_FLOAT+":"+RE_FLOAT+"\"";
-	const std::string TOKEN_BUTTON_RELEASE_DATAREF_CHANGE = "on_release=\"dataref:"+RE_REF+":"+RE_FLOAT+":"+RE_FLOAT+":"+RE_FLOAT+"\"";
-
-	const std::string TOKEN_CONDITIONAL_PUSH_DATAREF_CHANGE = "on_push=\"on_select:([a-zA-Z0-9_-]+),dataref:" + RE_REF + ":" + RE_FLOAT + ":" + RE_FLOAT + ":" + RE_FLOAT + "\"";
-	const std::string TOKEN_CONDITIONAL_PUSH_COMMANDREF = "on_push=\"on_select:([a-zA-Z0-9_-]+),commandref:" + RE_REF + ":([begin|end|once]*)\"";
-	const std::string TOKEN_CONDITIONAL_PUSH_LUA = "on_push=\"on_select:([a-zA-Z0-9_-]+),lua:" + RE_LUA + "\"";
-	const std::string TOKEN_CONDITIONAL_RELEASE_DATAREF_CHANGE = "on_release=\"on_select:([a-zA-Z0-9_-]+),dataref:" + RE_REF + ":" + RE_FLOAT + ":" + RE_FLOAT + ":" + RE_FLOAT + "\"";
-	const std::string TOKEN_CONDITIONAL_RELEASE_COMMANDREF = "on_release=\"on_select:([a-zA-Z0-9_-]+),commandref:" + RE_REF + ":([begin|end|once]*)\"";
-	const std::string TOKEN_CONDITIONAL_RELEASE_LUA = "on_release=\"on_select:([a-zA-Z0-9_-]+),lua:" + RE_LUA + "\"";
-
-	// Button light
-	const std::string TOKEN_LIGHT = "\\[light:id=\"([a-zA-Z0-9_-]+)\"\\]";
-	const std::string TOKEN_TRIGGER_LIT = "trigger_lit=\"dataref:"+RE_REF+":"+RE_FLOAT+"\"";
-	const std::string TOKEN_TRIGGER_UNLIT = "trigger_unlit=\"dataref:"+RE_REF+":"+RE_FLOAT+"\"";
-	const std::string TOKEN_TRIGGER_LIT_LUA = "trigger_lit=\"lua:" + RE_LUA + ":" + RE_FLOAT + "\"";
-	const std::string TOKEN_TRIGGER_UNLIT_LUA = "trigger_unlit=\"lua:" + RE_LUA + ":" + RE_FLOAT + "\"";
-	const std::string TOKEN_TRIGGER_BLINK = "trigger_blink=\"dataref:"+RE_REF+":"+RE_FLOAT+"\"";
-
-	// Rotary Encoder
-	const std::string TOKEN_ROT_ENCODER = "\\[encoder:id=\"([a-zA-Z0-9_-]+)\"\\]";
-	const std::string TOKEN_ROT_ENCODER_ON_INC_COMMANDREF = "on_increment=\"commandref:" + RE_REF + ":([begin|end|once]*)\"";
-	const std::string TOKEN_ROT_ENCODER_ON_DEC_COMMANDREF = "on_decrement=\"commandref:" + RE_REF + ":([begin|end|once]*)\"";
-	const std::string TOKEN_ROT_ENCODER_ON_INC_DATAREF_CHANGE = "on_increment=\"dataref:" + RE_REF + ":" + RE_FLOAT + ":" + RE_FLOAT + ":" + RE_FLOAT + "\"";
-	const std::string TOKEN_ROT_ENCODER_ON_DEC_DATAREF_CHANGE = "on_decrement=\"dataref:" + RE_REF + ":" + RE_FLOAT + ":" + RE_FLOAT + ":" + RE_FLOAT + "\"";
-	const std::string TOKEN_ROT_ENCODER_ON_INC_LUA = "on_increment=\"lua:" + RE_LUA + "\"";
-	const std::string TOKEN_ROT_ENCODER_ON_DEC_LUA = "on_decrement=\"lua:" + RE_LUA + "\"";
-
-	// Generic display
-	const std::string TOKEN_DISPLAY = "\\[display:id=\"([a-zA-Z0-9_-]+)\",bcd=\"(yes|no)\"\\]";
-	const std::string TOKEN_DISPLAY_LINE = "line=\"dataref:" + RE_REF + "\"";
-	const std::string TOKEN_DISPLAY_LINE_ARRAY = "line=\"dataref:" + RE_REF + "\\[" + RE_INT + "\\]\"";
-	const std::string TOKEN_DISPLAY_LINE_CONST = "line=\"const:" + RE_FLOAT + "\"";
-	const std::string TOKEN_DISPLAY_LINE_LUA = "line=\"lua:" + RE_LUA + "\"";
-
-	// Multi function Display
-	const std::string TOKEN_MULTI_DISPLAY = "\\[multi_display:id=\"([a-zA-Z0-9_-]+)\"\\]";
-	const std::string TOKEN_MULTI_DISPLAY_LINE = "line=\"on_select:([a-zA-Z0-9_-]+),dataref:"+RE_REF+"\"";
-	const std::string TOKEN_MULTI_DISPLAY_LINE_CONST = "line=\"on_select:([a-zA-Z0-9_-]+),const:" + RE_FLOAT + "\"";
-	const std::string TOKEN_MULTI_DISPLAY_LINE_LUA = "line=\"on_select:([a-zA-Z0-9_-]+),lua:" + RE_LUA + "\"";
-
-	// FIP screen
-	const std::string TOKEN_FIP_SCREEN = "\\[screen:id=\"([a-zA-Z0-9_-]+)\"\\]";
-	const std::string TOKEN_FIP_PAGE  = "\\[page:id=\"([a-zA-Z0-9_-]+)\"\\]";	
-	const std::string TOKEN_FIP_LAYER = "\\[layer:image=\"([a-zA-Z0-9_\\-/\\.]+),ref_x:" + RE_INT + ",ref_y:" + RE_INT + ",base_rot=" + RE_INT + "\"\\]";
-	const std::string TOKEN_FIP_TEXT_LAYER = "\\[layer:type=\"text\"\\]";
-	const std::string TOKEN_FIP_TEXT_VALUE_CONST = "text=\"const:" + RE_TEXT + "\"";
-	const std::string TOKEN_FIP_TEXT_VALUE_DATAREF = "text=\"dataref:" + RE_REF + "\"";
-	const std::string TOKEN_FIP_TEXT_VALUE_LUA = "text=\"lua:" + RE_LUA + "\"";
-	const std::string TOKEN_FIP_LAYER_MASK = "mask=\"screen_x:" + RE_INT + ",screen_y:" + RE_INT + ",height:" + RE_INT + ",width:" + RE_INT + "\"";
-	const std::string TOKEN_FIP_OFFSET_CONST = "offset_([xy]+)=\"const:" + RE_INT + "\"";
-	const std::string TOKEN_FIP_OFFSET_DATAREF = "offset_([xy]+)=\"dataref:" + RE_REF + ",scale:" + RE_FLOAT + "\"";
-	const std::string TOKEN_FIP_OFFSET_LUA = "offset_([xy]+)=\"lua:" + RE_LUA + "\"";
-	const std::string TOKEN_FIP_ROTATION_CONST = "rotation=\"const:" + RE_INT + "\"";
-	const std::string TOKEN_FIP_ROTATION_DATAREF = "rotation=\"dataref:" + RE_REF + ",scale:" + RE_FLOAT + "\"";
-	const std::string TOKEN_FIP_ROTATION_LUA = "rotation=\"lua:" + RE_LUA + "\"";
-
-	std::string section_id = "";
 	std::string last_error_message = "";
-	float speed_mid=0;
-	int multi_mid=1;
-	float speed_high=0;
-	int multi_high=1;
-	int current_line_nr=0;
-	int parse_line(std::string line, Configuration& config);
+	std::string last_device_id = "";
+	float speed_mid = 0;
+	int multi_mid = 1;
+	float speed_high = 0;
+	int multi_high = 1;
 public:
+	Configparser();
+	~Configparser();
 	int parse_file(std::string file_name, Configuration& config);
 };

--- a/src/GenericDisplay.cpp
+++ b/src/GenericDisplay.cpp
@@ -31,6 +31,11 @@ void GenericDisplay::set_nr_bytes(int _nr_of_bytes)
 	nr_of_bytes = _nr_of_bytes;
 }
 
+void GenericDisplay::set_bcd(bool _use_bcd)
+{
+	use_bcd = _use_bcd;
+}
+
 void GenericDisplay::add_dataref(XPLMDataRef _data_ref)
 {
 	dataref_index = -1;

--- a/src/GenericDisplay.h
+++ b/src/GenericDisplay.h
@@ -31,7 +31,7 @@ public:
 	void add_dataref(XPLMDataRef _data_ref, int _dataref_index);
 	void add_const(double _const_value);
 	void add_lua(std::string _lua_function);
-
+	void set_bcd(bool _use_bcd);
 protected:	
 	double	display_value;
 	double	display_value_old;

--- a/src/IniFileParser.cpp
+++ b/src/IniFileParser.cpp
@@ -1,0 +1,450 @@
+// 
+// cfg - A simple configuration file library.
+// 
+// Copyright (c) 2015-2017 Sean Farrell <sean.farrell@rioki.org>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// 
+
+// The original code is from: https://github.com/rioki/cfg 
+// I modified it a littlebit for the XPanel plugin's syntax 
+
+#include "IniFileParser.h"
+#include "Logger.h"
+#include <sstream>
+
+IniFileParser::IniFileParser()
+	: in(nullptr), next_token(NO_TOKEN), line(0), error_count(0)
+{
+
+}
+
+IniFileParser::~IniFileParser()
+{
+	clean();
+}
+
+IniFile& IniFileParser::get_parsed_ini_file()
+{
+	return parsed_ini_file;
+}
+
+int IniFileParser::get_number_of_errors()
+{
+	return error_count;
+}
+
+void IniFileParser::clean()
+{
+	parsed_ini_file.sections.clear();
+	parsed_ini_file.file_name = "";
+	error_count = 0;
+	line = 0;
+}
+
+void IniFileParser::parse(std::istream& _in, const std::string& _file, unsigned int _line)
+{
+	in = &_in;
+	file = _file;
+	line = 1;
+
+	clean();
+
+	IniFileSection root_section;
+	root_section.header.id = "";
+	root_section.header.name = "";
+	parsed_ini_file.file_name = _file;
+	parsed_ini_file.sections.emplace_back(root_section);
+
+	// prep the look ahead
+	std::string dummy;
+	get_next_token(dummy);
+
+	while (next_token != CONFIG_FILE_END)
+	{
+		if (next_token == NEWLINE)
+		{
+			// skip empty lines
+			get_next_token(dummy);
+		}
+		else if (next_token == IDENTIFIER)
+		{
+			parse_value_pair();
+		}
+		else
+		{
+			parse_section();
+		}
+
+	}
+}
+
+IniFileParser::Token IniFileParser::get_next_token(std::string& value)
+{
+	Token token = next_token;
+	value = next_value;
+
+	next_token = lex_token(next_value);
+	while (next_token == WHITESPACE || next_token == COMMENT)
+	{
+		next_token = lex_token(next_value);
+	}
+
+	return token;
+}
+
+IniFileParser::Token IniFileParser::lex_token(std::string& value)
+{
+	value.clear();
+	int c = in->get();
+	switch (c)
+	{
+	case ' ': case '\t': case '\v':
+		value.push_back(c);
+		return lex_whitespace(value);
+	case '\n': case '\r':
+		value.push_back(c);
+		return lex_newline(value);
+	case '0': case '1': case '2': case '3': case '4':
+	case '5': case '6': case '7': case '8': case '9':
+	case '-': case '+':
+		value.push_back(c);
+		return lex_number(value);
+	case 'a': case 'b': case 'c': case 'd': case 'e': case 'f':
+	case 'g': case 'h': case 'i': case 'j': case 'k': case 'l':
+	case 'm': case 'n': case 'o': case 'p': case 'q': case 'r':
+	case 's': case 't': case 'u': case 'v': case 'w': case 'x':
+	case 'y': case 'z':
+	case 'A': case 'B': case 'C': case 'D': case 'E': case 'F':
+	case 'G': case 'H': case 'I': case 'J': case 'K': case 'L':
+	case 'M': case 'N': case 'O': case 'P': case 'Q': case 'R':
+	case 'S': case 'T': case 'U': case 'V': case 'W': case 'X':
+	case 'Y': case 'Z':
+	case '_': case '.':
+		value.push_back(c);
+		return lex_identifier(value);
+	case '"':
+		return lex_string(value);
+	case '[':
+		value = "[";
+		return OPEN_BRACE;
+	case ']':
+		value = "]";
+		return CLOSE_BRACE;
+	case ':':
+	case ',':
+		return SEPARATOR;
+	case '=':
+		value = "=";
+		return EQUALS;
+	case ';':
+		return lex_comment(value);
+	case EOF:
+		return CONFIG_FILE_END;
+	default:
+		value.push_back(c);
+		error("Unexpected " + value);
+		return PARSER_ERROR;
+	}
+}
+
+IniFileParser::Token IniFileParser::lex_whitespace(std::string& value)
+{
+	int c = in->get();
+	while (true)
+	{
+		switch (c)
+		{
+		case ' ': case '\t': case '\v':
+			value.push_back(c);
+			break;
+		default:
+			in->unget();
+			return WHITESPACE;
+		}
+		c = in->get();
+	}
+}
+
+IniFileParser::Token IniFileParser::lex_newline(std::string& value)
+{
+	int c = in->get();
+	switch (c)
+	{
+	case '\n': case '\r':
+		if (c != value[0])
+		{
+			// \r\n or \n\r
+			value.push_back(c);
+		}
+		else
+		{
+			// treat \n \n as two newline, obviously
+			in->unget();
+		}
+		line++;
+		return NEWLINE;
+	default:
+		in->unget();
+		line++;
+		return NEWLINE;
+	}
+}
+
+IniFileParser::Token IniFileParser::lex_number(std::string& value)
+{
+	int c = in->get();
+	while (true)
+	{
+		// NOTE: not validating the actual format
+		switch (c)
+		{
+		case '0': case '1': case '2': case '3': case '4':
+		case '5': case '6': case '7': case '8': case '9':
+		case '.':
+			value.push_back(c);
+			break;
+		default:
+			in->unget();
+			return NUMBER;
+		}
+		c = in->get();
+	}
+}
+
+IniFileParser::Token IniFileParser::lex_identifier(std::string& value)
+{
+	int c = in->get();
+	while (true)
+	{
+		switch (c)
+		{
+		case '0': case '1': case '2': case '3': case '4':
+		case '5': case '6': case '7': case '8': case '9':
+		case 'a': case 'b': case 'c': case 'd': case 'e': case 'f':
+		case 'g': case 'h': case 'i': case 'j': case 'k': case 'l':
+		case 'm': case 'n': case 'o': case 'p': case 'q': case 'r':
+		case 's': case 't': case 'u': case 'v': case 'w': case 'x':
+		case 'y': case 'z':
+		case 'A': case 'B': case 'C': case 'D': case 'E': case 'F':
+		case 'G': case 'H': case 'I': case 'J': case 'K': case 'L':
+		case 'M': case 'N': case 'O': case 'P': case 'Q': case 'R':
+		case 'S': case 'T': case 'U': case 'V': case 'W': case 'X':
+		case 'Y': case 'Z':
+		case '_': case '-':
+			value.push_back(c);
+			break;
+		default:
+			in->unget();
+			return IDENTIFIER;
+		}
+		c = in->get();
+	}
+}
+
+IniFileParser::Token IniFileParser::lex_string(std::string& value)
+{
+	int c = in->get();
+	while (true)
+	{
+		switch (c)
+		{
+		case '"':
+			return STRING;
+		case '\n': case '\r': case EOF:
+			error("Unexpected newline in string");
+			return PARSER_ERROR;
+		case ' ': //skip every white spaces inside a string
+		case '\t':
+			break;
+		case '\\':
+			c = in->get();
+			switch (c)
+			{
+			case '\'':
+				value.push_back('\'');
+				break;
+			case '"':
+				value.push_back('"');
+				break;
+			case '\\':
+				value.push_back('\\');
+				break;
+			case 'a':
+				value.push_back('\a');
+				break;
+			case 'b':
+				value.push_back('\b');
+				break;
+			case 'f':
+				value.push_back('\f');
+				break;
+			case 'n':
+				value.push_back('\n');
+				break;
+			case 'r':
+				value.push_back('\r');
+				break;
+			case 't':
+				value.push_back('\t');
+				break;
+			case 'v':
+				value.push_back('\v');
+				break;
+			default:
+				error("Unknown escape sequence");
+				break;
+			}
+			break;
+		default:
+			value.push_back(c);
+			break;
+		}
+		c = in->get();
+	}
+}
+
+IniFileParser::Token IniFileParser::lex_comment(std::string& value)
+{
+	int c = in->get();
+	while (true)
+	{
+		switch (c)
+		{
+		case '\n': case '\r': case EOF:
+			line++;
+			return COMMENT;
+		default:
+			value.push_back(c);
+			break;
+		}
+		c = in->get();
+	}
+}
+
+void IniFileParser::parse_section()
+{
+	parse_section_header();
+
+	while (next_token == IDENTIFIER || next_token == NEWLINE)
+	{
+		parse_value_pair();
+	}
+}
+
+void IniFileParser::parse_section_header()
+{
+	std::string value;
+	Token t = get_next_token(value);
+
+	if (t != OPEN_BRACE)
+	{
+		error("Expected open breace");
+	}
+
+	t = get_next_token(value);
+	if (t != IDENTIFIER)
+	{
+		error("Expected identifier");
+	}
+	section = value;
+
+	IniFileSection new_section;
+
+	while ((t = get_next_token(value)) == SEPARATOR)
+	{
+		t = get_next_token(value);
+		if (t != IDENTIFIER)
+		{
+			error("Expected identifier");
+		}
+		std::string property_name = value;
+
+		t = get_next_token(value);
+		if (t != EQUALS)
+		{
+			error("Expected equals");
+		}
+
+		t = get_next_token(value);
+		if (t != IDENTIFIER && t != STRING && t != NUMBER)
+		{
+			error("Expected identifier or string");
+		}
+
+		new_section.header.properties[property_name] = value;
+	}
+
+	if (t != CLOSE_BRACE)
+	{
+		error("Expected close brace");
+	}
+
+	t = get_next_token(value);
+	if (t != NEWLINE && t != CONFIG_FILE_END)
+	{
+		error("Expected newline");
+	}
+
+	//id is the most frequent property in xpanel's config so save it on a dedicated variable as well
+	if (new_section.header.properties.count("id") > 0)
+		new_section.header.id = new_section.header.properties["id"];
+	else
+		new_section.header.id = "";
+
+	new_section.header.name = section;
+	new_section.header.line = line;
+	parsed_ini_file.sections.emplace_back(new_section);
+}
+
+void IniFileParser::parse_value_pair()
+{
+	std::string value;
+	Token t = get_next_token(value);
+
+	if (t == NEWLINE || t == COMMENT)
+	{
+		// accept empty line
+		return;
+	}
+
+	if (t != IDENTIFIER)
+	{
+		error("Expected identifier");
+	}
+	std::string key = value;
+
+	t = get_next_token(value);
+	if (t != EQUALS)
+	{
+		error("Expected equals");
+	}
+
+	t = get_next_token(value);
+	if (t == STRING || t == NUMBER)
+	{
+		parsed_ini_file.sections.back().key_value_pairs.emplace_back(key, value);
+	}
+}
+
+void IniFileParser::error(const std::string& msg)
+{
+	error_count++;
+	Logger(TLogLevel::logERROR) << "config error: " << file << "[" << line+1 << "]: " << msg << std::endl;
+}

--- a/src/IniFileParser.h
+++ b/src/IniFileParser.h
@@ -1,0 +1,126 @@
+// 
+// cfg - A simple configuration file library.
+// 
+// Copyright (c) 2015-2017 Sean Farrell <sean.farrell@rioki.org>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// 
+
+#ifndef _CFG_PARSER_H_
+#define _CFG_PARSER_H_
+
+#include <string>
+#include <iostream>
+#include <map>
+#include <vector>
+
+struct IniFileSectionHeader
+{
+	std::string name = "";
+	std::string id = "";
+	std::map<std::string, std::string> properties;
+	int line = 0;
+};
+
+struct IniFileSection
+{
+	IniFileSectionHeader header;
+	std::vector<std::pair<std::string, std::string>> key_value_pairs;
+};
+
+struct IniFile
+{
+	std::string file_name = "";
+	std::vector<IniFileSection> sections;
+};
+
+
+class IniFileParser
+{
+public:
+
+	IniFileParser();
+
+	~IniFileParser();
+
+	/**
+	 * Parse a stream.
+	 *
+	 * @param in   the stream to parse
+	 * @param file the file that is parsed, for error purposes
+	 * @param line the initial line
+	 **/
+	void parse(std::istream& in, const std::string& file = "", unsigned int line = 1);
+	IniFile& get_parsed_ini_file();
+	int get_number_of_errors();
+private:
+	enum Token
+	{
+		NO_TOKEN,
+		WHITESPACE,
+		OPEN_BRACE,  // [
+		CLOSE_BRACE, // ]
+		EQUALS,      // =
+		SEPARATOR, //:,
+		IDENTIFIER,  // [a-zA-Z_][a-zA-Z0-9_-]*
+		STRING,      // "([^"]*)"
+		NUMBER,		 // (+|-)[0-9]+(\.[0-9]+)
+		NEWLINE,     // \n|(\r\n)|\r
+		COMMENT,	 // #[^\n\r]*
+		CONFIG_FILE_END,
+		PARSER_ERROR		 // this should never be returned
+	};
+
+	IniFile parsed_ini_file;
+
+	std::istream* in;
+	std::string   file;
+	unsigned int  line;
+	int error_count;
+
+	Token next_token;
+	std::string next_value;
+
+	std::string section;
+
+	void clean();
+
+	Token get_next_token(std::string& value);
+
+	Token lex_token(std::string& value);
+	Token lex_whitespace(std::string& value);
+	Token lex_newline(std::string& value);
+	Token lex_number(std::string& value);
+	Token lex_identifier(std::string& value);
+	Token lex_string(std::string& value);
+	Token lex_comment(std::string& value);
+
+	void parse_section();
+
+	void parse_section_header();
+
+	void parse_value_pair();
+
+	void error(const std::string& msg);
+
+	IniFileParser(const IniFileParser&) = delete;
+	const IniFileParser& operator = (const IniFileParser&) = delete;
+};
+
+#endif

--- a/test/test-fip-screen-config.ini
+++ b/test/test-fip-screen-config.ini
@@ -9,30 +9,30 @@ serial="MZB05779E2"
     [screen:id="fip-screen"]
 
         [page:id="ADF"]
-            [layer:image="fip-images/Adf_Kompass_Ring.bmp,ref_x:0,ref_y:0,base_rot=0"]
+            [layer:image="fip-images/Adf_Kompass_Ring.bmp,ref_x:0,ref_y:0,base_rot:0"]
             offset_x="const:80"
             offset_y="const:0"
-            [layer:image="fip-images/adf_needle.bmp,ref_x:90,ref_y:8,base_rot=90"]
+            [layer:image="fip-images/adf_needle.bmp,ref_x:90,ref_y:8,base_rot:90"]
             offset_x="const:290"
             offset_y="const:129"
             rotation="dataref:sim/test1/test2,scale:-1.0"
 
         [page:id="SPEED"]
-            [layer:image="fip-images/Airspeed_Background.bmp,ref_x:0,ref_y:0,base_rot=0"]
+            [layer:image="fip-images/Airspeed_Background.bmp,ref_x:0,ref_y:0,base_rot:0"]
             offset_x="const:80"
             offset_y="const:0"
-            [layer:image="fip-images/Airspeed_Needle.bmp,ref_x:9,ref_y:7,base_rot=90"]
+            [layer:image="fip-images/Airspeed_Needle.bmp,ref_x:9,ref_y:7,base_rot:90"]
             offset_x="const:209"
             offset_y="const:129"
             rotation="dataref:sim/cockpit2/gauges/indicators/airspeed_kts_pilot,scale:1"
 
         [page:id="TEST_PADD"]
-            [layer:image="fip-images/bmp_test_padding.bmp,ref_x:0,ref_y:0,base_rot=0"]
+            [layer:image="fip-images/bmp_test_padding.bmp,ref_x:0,ref_y:0,base_rot:0"]
             offset_x="const:0"
             offset_y="const:0"
 
         [page:id="TEST_MASK"]
-            [layer:image="fip-images/bmp_test_big_image.bmp,ref_x:0,ref_y:157,base_rot=0"]
+            [layer:image="fip-images/bmp_test_big_image.bmp,ref_x:0,ref_y:157,base_rot:0"]
             offset_x="const:120"
             offset_y="const:0"
             mask="screen_x:0,screen_y:120,height:100,width:60"

--- a/test/test-valid-config.ini
+++ b/test/test-valid-config.ini
@@ -31,9 +31,9 @@ on_push="dataref:/sim/data/data_array[0]:1"
 
 ;Vertical speed dial on ABSU
 [button:id="TRIM_WHEEL_UP"]
-on_push="dataref:sim/custom/switchers/console/absu_pitch_wheel:1:15.0:-15.0"
+on_push="dataref:sim/custom/switchers/console/absu_pitch_wheel:1:-15.0:15.0"
 [button:id="TRIM_WHEEL_DOWN"]
-on_push="dataref:sim/custom/switchers/console/absu_pitch_wheel:-1:+15.0:-15.0"
+on_push="dataref:sim/custom/switchers/console/absu_pitch_wheel:-1:-15.0:+15.0"
 
 ;Silver knob on Multi panel
 [button:id="KNOB_PLUS"]

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -196,6 +196,7 @@ xcopy /y /d "$(SolutionDir)FIP-SDK\fonts\fip-fonts.bmp" "$(OutDir)"
     <ClCompile Include="..\src\FIPLayer.cpp" />
     <ClCompile Include="..\src\FIPTextLayer.cpp" />
     <ClCompile Include="..\src\GenericDisplay.cpp" />
+    <ClCompile Include="..\src\IniFileParser.cpp" />
     <ClCompile Include="..\src\Logger.cpp" />
     <ClCompile Include="..\src\LuaHelper.cpp" />
     <ClCompile Include="..\src\MessageWindow.cpp" />

--- a/test/test.vcxproj.filters
+++ b/test/test.vcxproj.filters
@@ -144,5 +144,8 @@
     <ClCompile Include="..\src\FIPTextLayer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\IniFileParser.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Refactor the configuration parser to use a recursive descent type parser instead of regexp based. 
- [x] support array type datarefs
- [x] fix unit test errors
- [x] add cmake
- [x] add extra checks for key-value pairs (stoi, stood, ...)
- [x] update documentation with changes in config syntax
- [x] prepare the change log for release notes

closes #6 