### PR TITLE
Dataref value in correct type

### DIFF
--- a/src/core/Action.cpp
+++ b/src/core/Action.cpp
@@ -44,6 +44,14 @@ Action::Action(XPLMDataRef dat, float d)
 	dataref_type = XPLMGetDataRefTypes(dataref);
 }
 
+Action::Action(XPLMDataRef dat, double d)
+{
+	dataref = dat;
+	data_f = (float)d;
+	index = -1; // dataref is not an array
+	dataref_type = XPLMGetDataRefTypes(dataref);
+}
+
 Action::Action(XPLMDataRef dat, int array_index, int d)
 {
 	dataref = dat;

--- a/src/core/Action.h
+++ b/src/core/Action.h
@@ -29,6 +29,7 @@ public:
 	Action();
 	Action(XPLMDataRef dat, int d);
 	Action(XPLMDataRef dat, float d);
+	Action(XPLMDataRef dat, double d);
 	Action(XPLMDataRef dat, int array_index, int d);
 	Action(XPLMDataRef dat, int array_index, float d);
 	Action(XPLMDataRef dat, float _delta, float _max, float _min);


### PR DESCRIPTION
The original implementation converted all the parsed dateref values into integers. It caused that values are truncated incorrectly.