### PR TITLE
Fix datareftype query

### DIFF
--- a/src/core/Action.cpp
+++ b/src/core/Action.cpp
@@ -33,7 +33,7 @@ Action::Action(XPLMDataRef dat, int d)
 	dataref = dat;
 	data = d;
 	index = -1; // dataref is not an array
-	dataref_type = XPLMGetDataRefTypes(dataref);
+	dataref_type = xplmType_Int;
 }
 
 Action::Action(XPLMDataRef dat, float d)
@@ -41,7 +41,7 @@ Action::Action(XPLMDataRef dat, float d)
 	dataref = dat;
 	data_f = d;
 	index = -1; // dataref is not an array
-	dataref_type = XPLMGetDataRefTypes(dataref);
+	dataref_type = xplmType_Float;
 }
 
 Action::Action(XPLMDataRef dat, double d)
@@ -49,7 +49,7 @@ Action::Action(XPLMDataRef dat, double d)
 	dataref = dat;
 	data_f = (float)d;
 	index = -1; // dataref is not an array
-	dataref_type = XPLMGetDataRefTypes(dataref);
+	dataref_type = xplmType_Double;
 }
 
 Action::Action(XPLMDataRef dat, int array_index, int d)
@@ -57,7 +57,7 @@ Action::Action(XPLMDataRef dat, int array_index, int d)
 	dataref = dat;
 	data = d;
 	index = array_index;
-	dataref_type = XPLMGetDataRefTypes(dataref);
+	dataref_type = xplmType_IntArray;
 }
 
 Action::Action(XPLMDataRef dat, int array_index, float d)
@@ -65,7 +65,7 @@ Action::Action(XPLMDataRef dat, int array_index, float d)
 	dataref = dat;
 	data_f = d;
 	index = array_index;
-	dataref_type = XPLMGetDataRefTypes(dataref);
+	dataref_type = xplmType_FloatArray;
 }
 
 Action::Action(XPLMDataRef dat, float _delta, float _max, float _min)

--- a/src/core/ConfigParser.cpp
+++ b/src/core/ConfigParser.cpp
@@ -357,6 +357,25 @@ void Configparser::check_and_get_array_index(std::string& dataref, int& index)
 	}
 }
 
+XPLMDataTypeID Configparser::normalize_dataref_type(XPLMDataTypeID data_ref_type)
+{
+	/* from xplane documenation:
+	   Data types each take a bit field; it is legal to have a single dataref 
+	   be more than one type of data. When this happens, you can pick 
+	   any matching get/set API.
+	*/
+	if (data_ref_type & xplmType_Double)
+		return xplmType_Double;
+	else if (data_ref_type & xplmType_Float)
+		return xplmType_Float;
+	else if (data_ref_type & xplmType_FloatArray)
+		return xplmType_FloatArray;
+	else if (data_ref_type & xplmType_IntArray)
+		return xplmType_IntArray;
+	else
+		return data_ref_type;
+}
+
 int Configparser::handle_on_push_or_release(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
 {
 	Action* action;
@@ -415,7 +434,7 @@ int Configparser::handle_on_push_or_release(IniFileSectionHeader section_header,
 		}
 		else
 		{
-			switch (XPLMGetDataRefTypes(dataRef)) {
+			switch (normalize_dataref_type(XPLMGetDataRefTypes(dataRef))) {
 			case xplmType_IntArray:
 				if (index < 0)
 				{
@@ -855,7 +874,7 @@ int Configparser::handle_on_fip_offset(IniFileSectionHeader section_header, std:
 			action->data_ref_index = index;
 
 		action->data_ref = dataRef;
-		action->data_ref_type = XPLMGetDataRefTypes(dataRef);
+		action->data_ref_type = normalize_dataref_type(XPLMGetDataRefTypes(dataRef));
 	}
 	else if (m[0] == TOKEN_LUA)
 	{
@@ -905,7 +924,7 @@ int Configparser::handle_on_fip_rotation(IniFileSectionHeader section_header, st
 			action->data_ref_index = index;
 
 		action->data_ref = dataRef;
-		action->data_ref_type = XPLMGetDataRefTypes(dataRef);
+		action->data_ref_type = normalize_dataref_type(XPLMGetDataRefTypes(dataRef));
 	}
 	else if (m[0] == TOKEN_LUA)
 	{
@@ -994,7 +1013,7 @@ int Configparser::handle_on_fip_text(IniFileSectionHeader section_header, std::s
 			return EXIT_FAILURE;
 		}
 		action->data_ref = dataRef;
-		action->data_ref_type = XPLMGetDataRefTypes(dataRef);
+		action->data_ref_type = normalize_dataref_type(XPLMGetDataRefTypes(dataRef));
 		action->type = SC_SET_TEXT;
 
 		Logger(logTRACE) << "config parser: add FIP text set dataref: " << action->data_ref << std::endl;

--- a/src/core/ConfigParser.h
+++ b/src/core/ConfigParser.h
@@ -39,6 +39,7 @@ private:
 	int handle_on_fip_mask(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config);
 	int handle_on_fip_text(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config);
 
+	XPLMDataTypeID normalize_dataref_type(XPLMDataTypeID data_ref_type);
 
 	const std::string TOKEN_VID = "vid";
 	const std::string TOKEN_PID = "pid";

--- a/src/core/LuaHelper.cpp
+++ b/src/core/LuaHelper.cpp
@@ -414,7 +414,22 @@ XPLMDataTypeID LuaHelper::get_dataref_type(XPLMDataRef dataref)
 	if (data_ref_types.count(dataref) == 0)
 	{
 		XPLMDataTypeID dataref_type = XPLMGetDataRefTypes(dataref);
-		data_ref_types[dataref] = dataref_type;
+
+		/* from xplane documenation:
+		Data types each take a bit field; it is legal to have a single dataref
+		be more than one type of data. When this happens, you can pick
+		any matching get/set API.
+		*/
+		if (dataref_type & xplmType_Double)
+			data_ref_types[dataref] = xplmType_Double;
+		else if (dataref_type & xplmType_Float)
+			data_ref_types[dataref] = xplmType_Float;
+		else if (dataref_type & xplmType_FloatArray)
+			data_ref_types[dataref] = xplmType_FloatArray;
+		else if (dataref_type & xplmType_IntArray)
+			data_ref_types[dataref] = xplmType_IntArray;
+		else
+			data_ref_types[dataref] = dataref_type;
 	}
 	return data_ref_types[dataref];
 }


### PR DESCRIPTION
XPlane uses bit field to store dataref type. The plugin shall be able to handle multiple datareftypes.

```
Data types each take a bit field; it is legal to have a single dataref be more than one type of data. 
When this happens, you can pick any matching get/set API.
```
closes #87 
