### PR TITLE
github actions: update linux version to latest

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-latest]
+        os: [ubuntu-22.04, windows-latest]
 
     name: Build and Test (CMake, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -59,9 +59,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install dependencies
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
-          sudo apt-get update -qq && sudo apt-get install -y build-essential cmake liblua5.3-dev libhidapi-dev
+          sudo apt-get update -qq && sudo apt-get install -y build-essential cmake liblua5.4-dev libhidapi-dev
           echo 'XPANEL_INSTALL_DEPS_FLAG=-DINSTALL_DEPS=ON' >> $GITHUB_ENV
 
 
@@ -76,8 +76,8 @@ jobs:
       - name: Install
         run: cmake --build build --target install
 
-      - name: Upload built plugin (Linux glibc 2.31)
-        if: matrix.os == 'ubuntu-20.04'
+      - name: Upload built plugin (Linux glibc 2.35)
+        if: matrix.os == 'ubuntu-22.04'
         uses: actions/upload-artifact@v3
         with:
           name: built-plugin-linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TAG: v${{ inputs.release-version }}
       WINDOWS_RELEASE_PLUGIN_ZIP: xpanel_windows_v${{ inputs.release-version }}.zip
-      LINUX_RELEASE_PLUGIN_ZIP: xpanel_linux_v${{ inputs.release-version }}_glibc2.31.zip
+      LINUX_RELEASE_PLUGIN_ZIP: xpanel_linux_v${{ inputs.release-version }}_glibc2.35.zip
       SAMPLE_CONFIG_ZIP: sample_configs_v${{ inputs.release-version }}.zip
 
     steps:


### PR DESCRIPTION
- Update linux runners from Ubuntu 20.04 to Ubuntu-latest. 
- Use liblua-dev instead of liblua5.3-dev