### PR TITLE
Handle multiple instance of the same VID/PID devices

### DIFF
--- a/src/core/UsbHidDevice.cpp
+++ b/src/core/UsbHidDevice.cpp
@@ -114,20 +114,37 @@ int UsbHidDevice::write_device(unsigned char* buf, int length)
 
 int UsbHidDevice::connect()
 {
-	device_handle = hid_open(vid, pid, NULL);
-	if (!device_handle) {
-		Logger(TLogLevel::logERROR) << "error opening hid device vid=" << vid << " pid=" << pid << " reason=" << hidapi_error(NULL) << std::endl;
-		return EXIT_FAILURE;
-	}
-	ref_count++;
+    struct hid_device_info *dev_info = hid_enumerate(vid, pid);
+    if (!dev_info) {
+        Logger(TLogLevel::logERROR) << "error enumerating hid device with vid=" << vid << " pid=" << pid << " reason=" << hidapi_error(NULL) << std::endl;
+        hid_free_enumeration(dev_info);
+        return EXIT_FAILURE;
+    }
 
-	if (hid_set_nonblocking(device_handle, 1) == -1) {
-		Logger(TLogLevel::logERROR) << "error in hid_set_nonblocking vid=" << vid << " pid=" << pid << " reason=" << hidapi_error(device_handle) << std::endl;
-		return EXIT_FAILURE;
-	}
+    device_handle = hid_open_path(dev_info->path);
+    if (!device_handle) {
+        Logger(TLogLevel::logERROR) << "error opening hid device vid=" << vid << " pid=" << pid << " reason=" << hidapi_error(NULL) << std::endl;
+        hid_free_enumeration(dev_info);
+        return EXIT_FAILURE;
+    }		
 
-	Logger(TLogLevel::logDEBUG) << "UsbHidDevice connect successful. vid=" << vid << " pid=" << pid << std::endl;
-	return EXIT_SUCCESS;
+    if (hid_set_nonblocking(device_handle, 1) == -1) {
+        Logger(TLogLevel::logERROR) << "error in hid_set_nonblocking vid=" << vid << " pid=" << pid << " reason=" << hidapi_error(device_handle) << std::endl;
+        hid_free_enumeration(dev_info);
+        return EXIT_FAILURE;
+    }
+
+    ref_count++;
+
+    if (dev_info->next) {
+        Logger(TLogLevel::logWARNING) << "found more than one device with vid=" << vid << " pid=" << pid << " Only the first device is used now. serial=" << dev_info->serial_number << std::endl; 
+    }
+
+    Logger(TLogLevel::logDEBUG) << "device opened: vid=" << vid << " pid=" << pid << " product=" << dev_info->product_string << " serial=" << dev_info->serial_number << std::endl;
+
+    hid_free_enumeration(dev_info);
+
+    return EXIT_SUCCESS;
 }
 
 void UsbHidDevice::start()

--- a/src/core/UsbHidDevice.cpp
+++ b/src/core/UsbHidDevice.cpp
@@ -137,14 +137,23 @@ int UsbHidDevice::connect()
     ref_count++;
 
     if (dev_info->next) {
-        Logger(TLogLevel::logWARNING) << "found more than one device with vid=" << vid << " pid=" << pid << " Only the first device is used now. serial=" << dev_info->serial_number << std::endl; 
+        Logger(TLogLevel::logWARNING) << "found more than one device with vid=" << vid << " pid=" << pid << " Only the first device is used now" << std::endl; 
     }
 
-    Logger(TLogLevel::logDEBUG) << "device opened: vid=" << vid << " pid=" << pid << " product=" << dev_info->product_string << " serial=" << dev_info->serial_number << std::endl;
+    Logger(TLogLevel::logDEBUG) << "device opened: vid=" << vid << " pid=" << pid << std::endl;
 
     hid_free_enumeration(dev_info);
 
     return EXIT_SUCCESS;
+}
+
+int UsbHidDevice::connect(hid_device* _device_handle)
+{
+	ref_count++;
+	device_handle = _device_handle;
+	Logger(TLogLevel::logDEBUG) << "device connect: vid=" << vid << " pid=" << pid << std::endl;
+
+	return EXIT_SUCCESS;
 }
 
 void UsbHidDevice::start()

--- a/src/core/UsbHidDevice.h
+++ b/src/core/UsbHidDevice.h
@@ -31,6 +31,7 @@ protected:
 	unsigned short vid = 0;
 	unsigned short pid = 0;
 	int connect();
+	int connect(hid_device* _device_handle);
 	virtual void start();
 	virtual void stop(int time_out);
 	void release();

--- a/src/devices/arduino-homecockpit/ArduinoHomeCockpit.cpp
+++ b/src/devices/arduino-homecockpit/ArduinoHomeCockpit.cpp
@@ -148,6 +148,27 @@ int ArduinoHomeCockpit::read_board_configuration(std::string file_name, unsigned
 	return exit_status;
 }
 
+int ArduinoHomeCockpit::connect(hid_device* _device_handle)
+{
+	if (_device_handle == NULL)
+	{
+		if (UsbHidDevice::connect() != EXIT_SUCCESS)
+		{
+			Logger(TLogLevel::logERROR) << "Arduin Home Cockpit connect. Error during connect" << std::endl;
+			return EXIT_FAILURE;
+		}
+	}
+	else
+	{
+		if (UsbHidDevice::connect(_device_handle) != EXIT_SUCCESS)
+		{
+			Logger(TLogLevel::logERROR) << "Arduin Home Cockpit connect. Error during connect" << std::endl;
+			return EXIT_FAILURE;
+		}
+	}
+	return EXIT_SUCCESS;
+}
+
 int ArduinoHomeCockpit::connect()
 {
 	return UsbHidDevice::connect();

--- a/src/devices/arduino-homecockpit/ArduinoHomeCockpit.h
+++ b/src/devices/arduino-homecockpit/ArduinoHomeCockpit.h
@@ -24,6 +24,7 @@ private:
 	const std::string TOKEN_DISPLAY = "display:id=\"([a-zA-Z0-9_-]+)\",width=([0-9]+)";
 public:
 	ArduinoHomeCockpit(DeviceConfiguration& config);
+	int connect(hid_device* _device_handle);
 	int connect();
 	void start();
 	void stop(int timeout);

--- a/src/devices/saitek-multi/SaitekMultiPanel.cpp
+++ b/src/devices/saitek-multi/SaitekMultiPanel.cpp
@@ -67,6 +67,27 @@ SaitekMultiPanel::SaitekMultiPanel(DeviceConfiguration& config) :UsbHidDevice(co
 	}
 }
 
+int SaitekMultiPanel::connect(hid_device* _device_handle)
+{
+	if (_device_handle == NULL)
+	{
+		if (UsbHidDevice::connect() != EXIT_SUCCESS)
+		{
+			Logger(TLogLevel::logERROR) << "SaitekMultiPanel connect. Error during connect" << std::endl;
+			return EXIT_FAILURE;
+		}
+	}
+	else
+	{
+		if (UsbHidDevice::connect(_device_handle) != EXIT_SUCCESS)
+		{
+			Logger(TLogLevel::logERROR) << "SaitekMultiPanel connect. Error during connect" << std::endl;
+			return EXIT_FAILURE;
+		}
+	}
+	return EXIT_SUCCESS;
+}
+
 int SaitekMultiPanel::connect()
 {
 	unsigned char buff[WRITE_BUFFER_SIZE];

--- a/src/devices/saitek-multi/SaitekMultiPanel.h
+++ b/src/devices/saitek-multi/SaitekMultiPanel.h
@@ -19,6 +19,7 @@ private:
 	std::vector<PanelDisplay> multi_displays;
 public:
 	SaitekMultiPanel(DeviceConfiguration &config);
+	int connect(hid_device* _device_handle);
 	int connect();
 	void start();
 	void stop(int timeout);

--- a/src/devices/saitek-radio/SaitekRadioPanel.cpp
+++ b/src/devices/saitek-radio/SaitekRadioPanel.cpp
@@ -64,10 +64,26 @@ SaitekRadioPanel::SaitekRadioPanel(DeviceConfiguration& config) :UsbHidDevice(co
 
 int SaitekRadioPanel::connect()
 {
-	if (UsbHidDevice::connect() != EXIT_SUCCESS)
+	return connect(NULL);
+}
+
+int SaitekRadioPanel::connect(hid_device* _device_handle)
+{
+	if (_device_handle == NULL) 
 	{
-		Logger(TLogLevel::logERROR) << "SaitekRadioPanel connect. Error during connect" << std::endl;
-		return EXIT_FAILURE;
+		if (UsbHidDevice::connect() != EXIT_SUCCESS)
+		{
+			Logger(TLogLevel::logERROR) << "SaitekRadioPanel connect. Error during connect" << std::endl;
+			return EXIT_FAILURE;
+		}
+	}
+	else
+	{
+		if (UsbHidDevice::connect(_device_handle) != EXIT_SUCCESS)
+		{
+			Logger(TLogLevel::logERROR) << "SaitekRadioPanel connect. Error during connect" << std::endl;
+			return EXIT_FAILURE;
+		}
 	}
 
 	read_device(read_buffer, read_buffer_size);

--- a/src/devices/saitek-radio/SaitekRadioPanel.h
+++ b/src/devices/saitek-radio/SaitekRadioPanel.h
@@ -19,6 +19,7 @@ private:
 public:
 	SaitekRadioPanel(DeviceConfiguration& config);
 	int connect();
+	int connect(hid_device* _device_handle);
 	void start();
 	void stop(int timeout);
 };

--- a/src/devices/saitek-switch/SaitekSwitchPanel.cpp
+++ b/src/devices/saitek-switch/SaitekSwitchPanel.cpp
@@ -53,6 +53,27 @@ SaitekSwitchPanel::SaitekSwitchPanel(DeviceConfiguration& config) :UsbHidDevice(
 	register_lights(switch_lights);
 }
 
+int SaitekSwitchPanel::connect(hid_device* _device_handle)
+{
+	if (_device_handle == NULL)
+	{
+		if (UsbHidDevice::connect() != EXIT_SUCCESS)
+		{
+			Logger(TLogLevel::logERROR) << "SaitekSwitchPanel connect. Error during connect" << std::endl;
+			return EXIT_FAILURE;
+		}
+	}
+	else
+	{
+		if (UsbHidDevice::connect(_device_handle) != EXIT_SUCCESS)
+		{
+			Logger(TLogLevel::logERROR) << "SaitekSwitchPanel connect. Error during connect" << std::endl;
+			return EXIT_FAILURE;
+		}
+	}
+    return EXIT_SUCCESS;
+}
+
 int SaitekSwitchPanel::connect()
 {
 	unsigned char buff[WRITE_BUFFER_SIZE];

--- a/src/devices/saitek-switch/SaitekSwitchPanel.h
+++ b/src/devices/saitek-switch/SaitekSwitchPanel.h
@@ -17,6 +17,7 @@ private:
 	std::vector<PanelLight> switch_lights;
 public:
 	SaitekSwitchPanel(DeviceConfiguration& config);
+	int connect(hid_device* _device_handle);
 	int connect();
 	void start();
 	void stop(int timeout);

--- a/src/devices/trc-1000/TRC1000.cpp
+++ b/src/devices/trc-1000/TRC1000.cpp
@@ -121,6 +121,27 @@ void TRC1000::thread_func()
 	Logger(TLogLevel::logDEBUG) << "TRC1000 thread_func: exit vid=" << vid << " pid=" << pid << std::endl;
 }
 
+int TRC1000::connect(hid_device* _device_handle)
+{
+	if (_device_handle == NULL)
+	{
+		if (UsbHidDevice::connect() != EXIT_SUCCESS)
+		{
+			Logger(TLogLevel::logERROR) << "TRC1000 connect. Error during connect" << std::endl;
+			return EXIT_FAILURE;
+		}
+	}
+	else
+	{
+		if (UsbHidDevice::connect(_device_handle) != EXIT_SUCCESS)
+		{
+			Logger(TLogLevel::logERROR) << "TRC1000 connect. Error during connect" << std::endl;
+			return EXIT_FAILURE;
+		}
+	}
+	return EXIT_SUCCESS;
+}
+
 int TRC1000::connect()
 {
 	if (UsbHidDevice::connect() != EXIT_SUCCESS)

--- a/src/devices/trc-1000/TRC1000.h
+++ b/src/devices/trc-1000/TRC1000.h
@@ -34,6 +34,7 @@ public:
 	TRC1000(DeviceConfiguration& config, int _read_buffer_size, int _write_buffer_size);
 	~TRC1000();
 	virtual void thread_func();
+	int connect(hid_device* _device_handle);
 	int connect();
 	void start();
 	void stop(int timeout);

--- a/test/mock_hid_api.cpp
+++ b/test/mock_hid_api.cpp
@@ -5,8 +5,10 @@
  */
 
 #pragma once
-#include"hidapi.h"
+#include "hidapi.h"
 #include <map>
+#include <sstream>
+#include <iostream>
 
 int device = 123;
 int vid = 0;
@@ -17,6 +19,38 @@ extern int HID_API_EXPORT HID_API_CALL hid_init()
 {
 	hid_device_open = false;
 	return 0;
+}
+
+extern struct hid_device_info HID_API_EXPORT* HID_API_CALL hid_enumerate(unsigned short vid, unsigned short pid)
+{
+	hid_device_info* dev_info = new hid_device_info();
+	dev_info->next = NULL;
+
+	dev_info->product_id = pid;
+	dev_info->vendor_id = vid;
+	dev_info->manufacturer_string = L"NorbiTest";
+	dev_info->serial_number = L"12345ABCD";
+
+	std::stringstream ss;
+	ss << vid << ' ' << pid;
+	dev_info->path = _strdup(ss.str().c_str());
+
+	return dev_info;
+}
+
+extern HID_API_EXPORT hid_device* HID_API_CALL hid_open_path(const char* path)
+{
+	std::stringstream ss;
+	ss << path;
+	ss >> vid >> pid;
+
+	hid_device_open = true;
+	return (hid_device*)&device;
+}
+
+extern void HID_API_EXPORT HID_API_CALL hid_free_enumeration(struct hid_device_info* devs)
+{
+	free(devs);
 }
 
 extern HID_API_EXPORT hid_device* HID_API_CALL hid_open(unsigned short vendor_id, unsigned short product_id, const wchar_t* serial_number)


### PR DESCRIPTION
This PR is created to support multiple instances of the same HID devices. For example, if you have 2 two saitek radio panels, the plugin shall be able to handle both devices. The configuration will be the same for both devices.
To be able to open more than one device with the same VID/PID, we have to use hid_enumerate hid_open_path functions.
