### PR TITLE
HID send feature report: set report id to 0

### DIFF
--- a/src/core/UsbHidDevice.cpp
+++ b/src/core/UsbHidDevice.cpp
@@ -86,6 +86,7 @@ int UsbHidDevice::send_feature_report(unsigned char* buf, int length)
 		return EXIT_FAILURE;
 	}
 
+	buf[0] = 0x00; // don't use report id
 	if (hid_send_feature_report(device_handle, buf, length) == -1)
 	{
 		Logger(TLogLevel::logERROR) << "error in UsbHidDevice::send_feature_report" << " reason=" << hidapi_error(device_handle) << std::endl;

--- a/src/devices/saitek-radio/SaitekRadioPanel.cpp
+++ b/src/devices/saitek-radio/SaitekRadioPanel.cpp
@@ -90,7 +90,7 @@ int SaitekRadioPanel::connect(hid_device* _device_handle)
 	memcpy(read_buffer_old, read_buffer, read_buffer_size);
 
 	unsigned char buff[WRITE_BUFFER_SIZE];
-	memset(buff, 0xff, sizeof(buff)); // clear all displays
+	memset(buff, 0x00, sizeof(buff)); // set all displays to 0
 	if (send_feature_report(buff, sizeof(buff)) != EXIT_SUCCESS)
 	{
 		Logger(TLogLevel::logERROR) << "SaitekRadioPanel connect. error in write_device" << std::endl;


### PR DESCRIPTION
According to #90 the first byte (index 0) of the feature report shall be set to 0. If it is 0 Linux kernel truncates it by 1 byte.

closes #90 