### PR TITLE
Dot position display

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -515,6 +515,18 @@ The below table contains some examples of different options. We suppose the disp
 | 100   | 00100                    | 100                                           | 100                                           |
 | 1500  | 01500                    | 1500                                          | 1500                                          |
 
+*Dot positionr*: You can add dot (period) character to the display lines. It is usefull when the numerical data is not an integer number. For example navigation radio frequesncies are in this form: 118.100 Mhz To add a dot caharacter to the display please use this option on the appropriate lines:
+```
+[multi_display:id="RADIO_DISPLAY_ACTIVE_UP"]
+line="on_select:SW_UP_COM1,dataref:sim/cockpit2/radios/actuators/com1_frequency_hz, dot_position: 2"
+```
+Here the ```dot_position``` option is an index starting at the most right position with index 0
+
+| value | dot_position:0 | dot_position:1 | dot_position:2 |
+| ------| -------------- | -------------- | -------------- |
+| 12345 | 12345.         | 1234.5         | 123.45         |
+
+
 ### Multipurpose displays
 The display value can be a conditional display which means the value to display depends on the position of a switch. A display that contains conditions called multi-purpose display (multi_display).
 

--- a/src/core/ConfigParser.cpp
+++ b/src/core/ConfigParser.cpp
@@ -626,6 +626,7 @@ int Configparser::handle_on_lit_or_unlit_or_blink(IniFileSectionHeader section_h
 int Configparser::handle_on_line_add(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
 {
 	//line="on_select:SW_ALT,dataref:sim/custom/gauges/compas/pkp_helper_course_L"
+	//line="on_select:SW_ALT,dataref:sim/custom/gauges/compas/pkp_helper_course_L, dot_position: 2" 
 	//line="on_select:SW_ALT,dataref:sim/custom/gauges/compas/pkp_helper_course_L, minimum_digit_number: 3"
 	//line="dataref:sim/custom/gauges/compas/pkp_helper_course_L"
 	//line="dataref:sim/custom/gauges/compas/test[0] 
@@ -651,6 +652,21 @@ int Configparser::handle_on_line_add(IniFileSectionHeader section_header, std::s
 			config.class_configs.back().multi_displays[section_header.id]->set_minimum_number_of_digits(condition, stoi(min_digit_number));
 		else if(section_header.name == TOKEN_SECTION_DISPLAY)
 			config.class_configs.back().generic_displays[section_header.id]->set_minimum_number_of_digits(stoi(min_digit_number));
+		else
+		{
+			Logger(TLogLevel::logERROR) << "parser: invalid line for device type: " << section_header.name << std::endl;
+			return EXIT_FAILURE;
+		}
+	}
+
+	std::string dot_position = "";
+	get_and_remove_token_pair(m, TOKEN_DOT_POSITION, dot_position);
+	if (dot_position != "")
+	{
+		if (section_header.name == TOKEN_SECTION_MULTI_DISPLAY)
+			config.class_configs.back().multi_displays[section_header.id]->set_dot_position(condition, stoi(dot_position));
+		else if (section_header.name == TOKEN_SECTION_DISPLAY)
+			config.class_configs.back().generic_displays[section_header.id]->set_dot_position(stoi(dot_position));
 		else
 		{
 			Logger(TLogLevel::logERROR) << "parser: invalid line for device type: " << section_header.name << std::endl;

--- a/src/core/ConfigParser.h
+++ b/src/core/ConfigParser.h
@@ -84,6 +84,7 @@ private:
 	const std::string TOKEN_BCD = "bcd";
 	const std::string TOKEN_BLANK_LEADING_ZEROS = "blank_leading_zeros";
 	const std::string TOKEN_MIN_DIGIT_NUMBER = "minimum_digit_number";
+	const std::string TOKEN_DOT_POSITION = "dot_position";
 	const std::string TOKEN_ON_SELECT = "on_select";
 	const std::string TOKEN_BEGIN = "begin";
 	const std::string TOKEN_END = "end";

--- a/src/core/GenericDisplay.h
+++ b/src/core/GenericDisplay.h
@@ -25,8 +25,9 @@ public:
 	void set_nr_bytes(int _nr_of_bytes);
 
 	// called from UsbHidDevice worker thread
-	virtual bool get_display_value(unsigned char* buffer, int _minimum_number_of_digits);
+	virtual bool get_display_value(unsigned char* buffer, int _minimum_number_of_digits, int _dot_position);
 	virtual int get_minimum_number_of_digits();
+	virtual int get_dot_position();
 
 	// called from XPLane flight loop
 	virtual void evaluate_and_store_dataref_value();
@@ -37,6 +38,7 @@ public:
 	void set_bcd(bool _use_bcd);
 	void set_blank_leading_zeros(bool _blank_leading_zeros);
 	void set_minimum_number_of_digits(int _minimum_number_of_digits);
+	void set_dot_position(int _dot_position);
 protected:	
 	double	display_value;
 	double	display_value_old;
@@ -45,6 +47,7 @@ protected:
 	bool use_bcd;
 	bool blank_leading_zeros;
 	int minimum_number_of_digits;
+	int dot_position;
 	std::string lua_function;
 	XPLMDataRef condition;
 	XPLMDataTypeID data_ref_type;
@@ -53,7 +56,9 @@ protected:
 private:
 	const unsigned char BLANK_CHAR = 0xFF;
 	const unsigned char ZERO_CHAR = 0x00;
+	const unsigned char PERIOD_CHAR = 0xD0;
+
 	int dataref_index;
-	bool get_decimal_components(int number, unsigned char* buffer, int _minimum_number_of_digits);
+	bool get_decimal_components(int number, unsigned char* buffer, int _minimum_number_of_digits, int _dot_position);
 	bool get_binary_components(int number, unsigned char* buffer);
 };

--- a/src/core/MultiPurposeDisplay.cpp
+++ b/src/core/MultiPurposeDisplay.cpp
@@ -36,6 +36,7 @@ MultiPurposeDisplay::MultiPurposeDisplay(MultiPurposeDisplay* other)
 	minimum_number_of_digits = other->minimum_number_of_digits;
 	blank_leading_zeros = other->blank_leading_zeros;
 	minimum_number_of_digits_for_condtions = other->minimum_number_of_digits_for_condtions;
+	dot_positions_for_conditions = other->dot_positions_for_conditions;
 }
 
 void MultiPurposeDisplay::add_condition(std::string selector_sw_name, XPLMDataRef data)
@@ -101,6 +102,12 @@ void MultiPurposeDisplay::set_minimum_number_of_digits(std::string _condition, i
 	Logger(TLogLevel::logDEBUG) << "MultiPurposeDisplay: set minimum number of digits [" + _condition + "]: " << _minimum_number_of_digits << std::endl;
 }
 
+void MultiPurposeDisplay::set_dot_position(std::string _condition, int _dot_position)
+{
+	dot_positions_for_conditions[_condition] = _dot_position;
+	Logger(TLogLevel::logDEBUG) << "MultiPurposeDisplay: set dot position [" + _condition + "]: " << _dot_position << std::endl;
+}
+
 int MultiPurposeDisplay::get_minimum_number_of_digits()
 {
 	int result = 1;
@@ -111,6 +118,22 @@ int MultiPurposeDisplay::get_minimum_number_of_digits()
 		result = minimum_number_of_digits_for_condtions[active_condition];
 	else
 		result = 1; //default 1
+
+	guard.unlock();
+
+	return result;
+}
+
+int MultiPurposeDisplay::get_dot_position()
+{
+	int result = -1;
+
+	guard.lock();
+
+	if (dot_positions_for_conditions.count(active_condition) != 0)
+		result = dot_positions_for_conditions[active_condition];
+	else
+		result = -1; //default -1 --> no dot
 
 	guard.unlock();
 

--- a/src/core/MultiPurposeDisplay.h
+++ b/src/core/MultiPurposeDisplay.h
@@ -24,7 +24,9 @@ public:
 	void add_condition(std::string selector_sw_name, std::string lua_str);
 
 	void set_minimum_number_of_digits(std::string _condition, int _minimum_number_of_digits);
+	void set_dot_position(std::string _condition, int _dot_position);
 	int get_minimum_number_of_digits();
+	int get_dot_position();
 
 	// called from UsbHidDevice worker thread
 	void set_condition_active(std::string selector_sw_name);
@@ -38,6 +40,8 @@ private:
 	std::map<std::string, std::string> lua_functions;
 	std::map<std::string, XPLMDataTypeID> data_ref_types;
 	std::map<std::string, int> minimum_number_of_digits_for_condtions;
+	std::map<std::string, int> dot_positions_for_conditions;
+
 	std::string active_condition;
 	double	display_value;
 	double	display_value_old;

--- a/src/core/UsbHidDevice.cpp
+++ b/src/core/UsbHidDevice.cpp
@@ -192,7 +192,8 @@ bool UsbHidDevice::updateOneDisplay(std::pair<std::string, GenericDisplay*> conf
 	if (reg_index != -1 && config_display.second != NULL)
 	{
 		int minimum_number_of_digits = config_display.second->get_minimum_number_of_digits();
-		write_buffer_changed |= config_display.second->get_display_value(&write_buffer[reg_index], minimum_number_of_digits);
+		int dot_position = config_display.second->get_dot_position();
+		write_buffer_changed |= config_display.second->get_display_value(&write_buffer[reg_index], minimum_number_of_digits, dot_position);
 	}
 
 	return write_buffer_changed;


### PR DESCRIPTION
This PR adds the dot (period) option to display lines.

To add a dot for a given display line, you need to use the ```dot_position``` property. The 0 index is the most right dot character.

For example to display 123.45 you have to set the dot_position like this:

```ini
[multi_display:id="RADIO_DISPLAY_ACTIVE_UP"]
line="on_select:SW_UP_COM1,dataref:sim/cockpit2/radios/actuators/com1_frequency_hz, dot_position: 2"
```


closes #105 