### PR TITLE
Generic display: add period to the end of the file in case of truncate

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -526,6 +526,20 @@ Here the ```dot_position``` option is an index starting at the most right positi
 | ------| -------------- | -------------- | -------------- |
 | 12345 | 12345.         | 1234.5         | 123.45         |
 
+### Display Value Truncation
+#### Overview
+When displaying values on hardware panels with limited character capacity, XPanel automatically handles cases where the data exceeds the available display space.
+
+#### Truncation Behavior
+If a display value is wider than the available characters on the hardware display, XPanel will truncate the value and append a period (`.`) character at the end to indicate that the value has been shortened.
+
+**Example:**
+- **Full value**: `120.375` (8.33kHz radio frequency)
+- **Saitek Radio Panel display** (5 characters): `12037.`
+- The period at the end indicates that the complete value cannot be displayed
+
+#### Configuration
+The truncation behavior is automatically applied and does not require any configuration. The feature ensures that users are always aware when displayed values are incomplete due to hardware limitations.
 
 ### Multipurpose displays
 The display value can be a conditional display which means the value to display depends on the position of a switch. A display that contains conditions called multi-purpose display (multi_display).

--- a/src/core/GenericDisplay.cpp
+++ b/src/core/GenericDisplay.cpp
@@ -161,17 +161,29 @@ bool GenericDisplay::get_decimal_components(int number, unsigned char* buffer, i
 		negative = true;
 	}
 
-	if (number > pow(10, nr_of_bytes))
-		return false;
+	for (int i = 0; i < nr_of_bytes; i++)
+		buffer[i] = ZERO_CHAR;
 
-	int remain = number;
-	for (int dec_pos = nr_of_bytes - 1; dec_pos >= 0; dec_pos--)
+	if (number != 0)
 	{
-		buffer[nr_of_bytes - 1 - dec_pos] = remain / (int)pow(10, dec_pos);
-		if (dec_pos == _dot_position)
-			buffer[nr_of_bytes - 1 - dec_pos] += PERIOD_CHAR; // turn on period dot
+		// how many decimal positions do we need?
+		const int base_10_of_number = (int)log10(number);
 
-		remain = remain % (int)pow(10, dec_pos);
+		int remain = number;
+		int buffer_index = nr_of_bytes > (base_10_of_number + 1) ? nr_of_bytes - (base_10_of_number+1) : 0;
+
+		for (int dec_pos = base_10_of_number; dec_pos >= 0 && buffer_index < nr_of_bytes; dec_pos--)
+		{
+			buffer[buffer_index] = remain / (int)pow(10, dec_pos);
+			if (dec_pos == _dot_position)
+				buffer[buffer_index] += PERIOD_CHAR; // turn on period dot
+
+			remain = remain % (int)pow(10, dec_pos);
+			buffer_index++;
+		}
+
+		if (remain != 0)
+			buffer[nr_of_bytes - 1] += PERIOD_CHAR; // a dot at the end of display indicates the truncated line
 	}
 
 	if (blank_leading_zeros)

--- a/test/test-radio-panel-config.ini
+++ b/test/test-radio-panel-config.ini
@@ -10,11 +10,12 @@ pid="d05"
 
 [multi_display:id="RADIO_DISPLAY_ACTIVE_UP"]
 line="on_select:SW_UP_COM1,dataref:sim/cockpit2/radios/actuators/com1_frequency_hz"
-line="on_select:SW_UP_COM2,dataref:sim/cockpit/radios/com1_stdby_freq_hz"
+line="on_select:SW_UP_COM2,dataref:sim/cockpit2/radios/actuators/com1_frequency_hz_833"
 line="on_select:SW_UP_NAV1,dataref:sim/cockpit2/radios/actuators/nav1_frequency_hz"
 line="on_select:SW_UP_NAV2,dataref:sim/cockpit2/radios/actuators/nav2_frequency_hz"
 line="on_select:SW_UP_ADF,const:12345"
 line="on_select:SW_UP_DME,lua:get_display_value()"
+line="on_select:SW_UP_IDT,dataref:sim/cockpit2/radios/actuators/transponder_code"
 
 [button:id="KNOB_UP_BIG_PLUS"]
 on_push="on_select:SW_UP_COM1,dataref:sim/cockpit2/radios/actuators/com1_frequency_hz:100:0:99999"


### PR DESCRIPTION
If a value is wider than the available characters on the display, put a period symbol to the end of the line. This could be the case if you use Saitek Radio panel (five digits) and 8.33kHz radio channels (for example 120.375 Mhz). In this case, the display will show this: ```12037.``` Not the period character at the end.
