### PR TITLE
Small bug fixes and refactors

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -75,9 +75,15 @@ jobs:
           cmake -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install" -S . -B build ${XPANEL_INSTALL_DEPS_FLAG}
           cmake --build build
 
-      - name: Run tests
-        if: matrix.os != 'windows-latest'
-        run: ctest --test-dir build --output-on-failure
+      - name: Run tests ubuntu
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          ctest --test-dir build --output-on-failure
+      
+      - name: Run tests macOS
+        if: matrix.os == 'macos-latest'
+        run: |
+          ctest --test-dir build --output-on-failure -E test_dynamic_speed
 
       - name: Install
         run: cmake --build build --target install

--- a/src/core/Action.cpp
+++ b/src/core/Action.cpp
@@ -310,7 +310,7 @@ void Action::activate()
 	if (!lua_str.empty())
 	{
 		Logger(TLogLevel::logTRACE) << "activate lua action: " << lua_str << std::endl;;
-		LuaHelper::get_instace()->do_string(lua_str);
+		LuaHelper::get_instance()->do_string(lua_str);
 	}
 }
 

--- a/src/core/Action.cpp
+++ b/src/core/Action.cpp
@@ -337,7 +337,8 @@ void ActionQueue::push(Action* action)
 	int multi_mid, multi_high;
 	action->get_dynamic_speed_params(&tick_per_sec_mid, &multi_mid, &tick_per_sec_high, &multi_high);
 	
-	guard.lock();
+	std::lock_guard<std::mutex> lock(guard);
+
 	if (tick_per_sec_mid != 0 || tick_per_sec_high != 0)
 	{		
 		if (action_ageing_counters.count(action->get_hash()) == 0) {
@@ -361,12 +362,11 @@ void ActionQueue::push(Action* action)
 	}
 
 	action_queue.push_back(action);
-	guard.unlock();
 }
 
 void ActionQueue::activate_actions_in_queue()
 {
-	guard.lock();
+	std::lock_guard<std::mutex> lock(guard);
 
 	while (!action_queue.empty())
 	{
@@ -377,18 +377,15 @@ void ActionQueue::activate_actions_in_queue()
 
 		action_queue.pop_front();
 	}
-
-	guard.unlock();
 }
 
 void ActionQueue::clear_all_actions()
 {
-	guard.lock();
+	std::lock_guard<std::mutex> lock(guard);
 	action_queue.clear();
 	for (auto it = action_ageing_counters.begin(); it != action_ageing_counters.end(); ++it)
 	{
 		delete(it->second);
 	}
 	action_ageing_counters.clear();
-	guard.unlock();
 }

--- a/src/core/Action.cpp
+++ b/src/core/Action.cpp
@@ -12,7 +12,7 @@
 #include <cmath>
 #include <functional>
 
-Action::Action()
+void Action::init_all_fields()
 {
 	data = 0;
 	data_f = 0.0f;
@@ -34,8 +34,15 @@ Action::Action()
 	commandref = NULL;
 }
 
+Action::Action()
+{
+	init_all_fields();
+}
+
 Action::Action(Action* other)
 {
+	init_all_fields();
+
 	data = other->data;
 	data_f = other->data_f;
 	index = other->index;
@@ -58,116 +65,47 @@ Action::Action(Action* other)
 
 Action::Action(XPLMCommandRef cmd, CommandType type)
 {
-	data = 0;
-	data_f = 0.0f;
-	index = -1;
-	delta = 0;
-	tick_per_sec_mid = 0.0f;
-	tick_per_sec_high = 0.0f;
-	multi_low = 1;
-	multi_high = 1;
-	multi = 1;
-	max = 0.0f;
-	min = 0.0f;
-	lua_str = "";
-	condition = "";
-	active_conditions.clear();
-	dataref = NULL;
+	init_all_fields();
 	commandref = cmd;
 	command_type = type;
-	dataref_type = xplmType_Unknown;
 }
 
 Action::Action(XPLMDataRef dat, int d)
 {
+	init_all_fields();
 	data = d;
-	data_f = 0.0f;
-	index = -1; // dataref is not an array
-	delta = 0;
-	tick_per_sec_mid = 0.0f;
-	tick_per_sec_high = 0.0f;
-	multi_low = 1;
-	multi_high = 1;
-	multi = 1;
-	max = 0.0f;
-	min = 0.0f;
-	lua_str = "";
-	condition = "";
-	active_conditions.clear();
 	dataref = dat;
 	dataref_type = xplmType_Int;
-	command_type = CommandType::NONE;
-	commandref = NULL;
 }
 
 Action::Action(XPLMDataRef dat, float d)
 {
-	data = 0;
+	init_all_fields();
 	data_f = d;
-	index = -1; // dataref is not an array
-	delta = 0;
-	tick_per_sec_mid = 0.0f;
-	tick_per_sec_high = 0.0f;
-	multi_low = 1;
-	multi_high = 1;
-	multi = 1;
-	max = 0.0f;
-	min = 0.0f;
-	lua_str = "";
-	condition = "";
-	active_conditions.clear();
 	dataref = dat;
 	dataref_type = xplmType_Float;
-	command_type = CommandType::NONE;
-	commandref = NULL;
 }
 
 Action::Action(XPLMDataRef dat, double d)
 {
-	data = 0;
-	data_f = (float)d;
-	index = -1; // dataref is not an array
-	delta = 0;
-	tick_per_sec_mid = 0.0f;
-	tick_per_sec_high = 0.0f;
-	multi_low = 1;
-	multi_high = 1;
-	multi = 1;
-	max = 0.0f;
-	min = 0.0f;
-	lua_str = "";
-	condition = "";
-	active_conditions.clear();
+	init_all_fields();
 	dataref = dat;
 	dataref_type = xplmType_Double;
-	command_type = CommandType::NONE;
-	commandref = NULL;
+	data_f = (float)d;
 }
 
 Action::Action(XPLMDataRef dat, int array_index, int d)
 {
-	data = d;
-	data_f = 0.0f;
-	index = array_index;
-	delta = 0;
-	tick_per_sec_mid = 0.0f;
-	tick_per_sec_high = 0.0f;
-	multi_low = 1;
-	multi_high = 1;
-	multi = 1;
-	max = 0.0f;
-	min = 0.0f;
-	lua_str = "";
-	condition = "";
-	active_conditions.clear();
+	init_all_fields();
 	dataref = dat;
 	dataref_type = xplmType_IntArray;
-	command_type = CommandType::NONE;
-	commandref = NULL;
+	data = d;
+	index = array_index;
 }
 
 Action::Action(XPLMDataRef dat, int array_index, float d)
 {
+	init_all_fields();
 	dataref = dat;
 	data_f = d;
 	index = array_index;
@@ -176,6 +114,7 @@ Action::Action(XPLMDataRef dat, int array_index, float d)
 
 Action::Action(XPLMDataRef dat, float _delta, float _max, float _min)
 {
+	init_all_fields();
 	dataref = dat;
 	delta = _delta;
 	max = _max;
@@ -188,6 +127,7 @@ Action::Action(XPLMDataRef dat, float _delta, float _max, float _min)
 
 Action::Action(std::string _lua_str)
 {
+	init_all_fields();
 	lua_str = _lua_str;
 }
 

--- a/src/core/Action.h
+++ b/src/core/Action.h
@@ -47,6 +47,7 @@ public:
 	int get_hash();
 	void activate();
 private:
+	void init_all_fields();
 	int data = 0;
 	float data_f = 0;
 	int index = -1;

--- a/src/core/AgeingCounter.cpp
+++ b/src/core/AgeingCounter.cpp
@@ -22,9 +22,8 @@ void AgeingCounter::event_happend(int nr_of_event)
 	event.time_of_event = get_current_time();
 	event.number_of_event = nr_of_event;
 
-	guard.lock();
+	std::lock_guard<std::mutex> lock(guard);
 	list.push_back(event);
-	guard.unlock();
 }
 
 int AgeingCounter::get_nr_of_events_not_older_than(uint64_t max_age)
@@ -32,15 +31,13 @@ int AgeingCounter::get_nr_of_events_not_older_than(uint64_t max_age)
 	int count = 0;
 	uint64_t current_time = get_current_time();
 
-	guard.lock();
+	std::lock_guard<std::mutex> lock(guard);
 	for (auto& ev : list)
 	{
 		if (ev.time_of_event + max_age >= current_time) {
 			count += ev.number_of_event;
 		}
 	}
-	guard.unlock();
-
 	return count;
 }
 
@@ -48,7 +45,7 @@ void AgeingCounter::clear_old_events(uint64_t max_age)
 {
 	uint64_t current_time = get_current_time();
 
-	guard.lock();
+	std::lock_guard<std::mutex> lock(guard);
 	auto it = list.cbegin();
 	while (it != list.cend())
 	{
@@ -57,5 +54,4 @@ void AgeingCounter::clear_old_events(uint64_t max_age)
 		else
 			++it;
 	}
-	guard.unlock();
 }

--- a/src/core/ConfigParser.cpp
+++ b/src/core/ConfigParser.cpp
@@ -239,7 +239,10 @@ int Configparser::process_fip_layer_section(IniFileSection& section, Configurati
 			std::filesystem::path bmp_file_absolute_path = std::filesystem::path(config.aircraft_path);
 			bmp_file_absolute_path /= std::string(m[0]);
 
-			int ref_x, ref_y, base_rot;
+			int ref_x = 0; 
+			int ref_y = 0;
+			int base_rot = 0;
+
 			for (int i = 1; i <= 6; i += 2)
 			{
 				if (m[i] == "ref_x")

--- a/src/core/ConfigParser.cpp
+++ b/src/core/ConfigParser.cpp
@@ -16,38 +16,38 @@
 #include "fip/FIPScreen.h"
 #include "core/Logger.h"
 
-Configparser::Configparser()
+ConfigParser::ConfigParser()
 {
-	process_functions[TOKEN_ON_PUSH] = &Configparser::handle_on_push_or_release;
-	process_functions[TOKEN_ON_RELEASE] = &Configparser::handle_on_push_or_release;
-	process_functions[TOKEN_VID] = &Configparser::handle_on_vid;
-	process_functions[TOKEN_PID] = &Configparser::handle_on_pid;
-	process_functions[TOKEN_LOG_LEVEL] = &Configparser::handle_on_log_level;
-	process_functions[TOKEN_ACF] = &Configparser::handle_on_acf_file;
-	process_functions[TOKEN_SCRIPT] = &Configparser::handle_on_script_file;
-	process_functions[TOKEN_LIT] = &Configparser::handle_on_lit_or_unlit_or_blink;
-	process_functions[TOKEN_UNLIT] = &Configparser::handle_on_lit_or_unlit_or_blink;
-	process_functions[TOKEN_BLINK] = &Configparser::handle_on_lit_or_unlit_or_blink;
-	process_functions[TOKEN_DYN_SPEED_MID] = &Configparser::handle_on_dynamic_speed;
-	process_functions[TOKEN_DYN_SPEED_HIGH] = &Configparser::handle_on_dynamic_speed;
-	process_functions[TOKEN_DISPLAY_LINE] = &Configparser::handle_on_line_add;
-	process_functions[TOKEN_BCD] = &Configparser::handle_on_set_bcd;
-	process_functions[TOKEN_ENCODER_INC] = &Configparser::handle_on_encoder_inc_or_dec;
-	process_functions[TOKEN_ENCODER_DEC] = &Configparser::handle_on_encoder_inc_or_dec;
-	process_functions[TOKEN_SERIAL] = &Configparser::handle_on_fip_serial;
-	process_functions[TOKEN_FIP_OFFSET_X] = &Configparser::handle_on_fip_offset;
-	process_functions[TOKEN_FIP_OFFSET_Y] = &Configparser::handle_on_fip_offset;
-	process_functions[TOKEN_FIP_ROTATION] = &Configparser::handle_on_fip_rotation;
-	process_functions[TOKEN_FIP_MASK] = &Configparser::handle_on_fip_mask;
-	process_functions[TOKEN_FIP_TEXT] = &Configparser::handle_on_fip_text;
+	process_functions[TOKEN_ON_PUSH] = &ConfigParser::handle_on_push_or_release;
+	process_functions[TOKEN_ON_RELEASE] = &ConfigParser::handle_on_push_or_release;
+	process_functions[TOKEN_VID] = &ConfigParser::handle_on_vid;
+	process_functions[TOKEN_PID] = &ConfigParser::handle_on_pid;
+	process_functions[TOKEN_LOG_LEVEL] = &ConfigParser::handle_on_log_level;
+	process_functions[TOKEN_ACF] = &ConfigParser::handle_on_acf_file;
+	process_functions[TOKEN_SCRIPT] = &ConfigParser::handle_on_script_file;
+	process_functions[TOKEN_LIT] = &ConfigParser::handle_on_lit_or_unlit_or_blink;
+	process_functions[TOKEN_UNLIT] = &ConfigParser::handle_on_lit_or_unlit_or_blink;
+	process_functions[TOKEN_BLINK] = &ConfigParser::handle_on_lit_or_unlit_or_blink;
+	process_functions[TOKEN_DYN_SPEED_MID] = &ConfigParser::handle_on_dynamic_speed;
+	process_functions[TOKEN_DYN_SPEED_HIGH] = &ConfigParser::handle_on_dynamic_speed;
+	process_functions[TOKEN_DISPLAY_LINE] = &ConfigParser::handle_on_line_add;
+	process_functions[TOKEN_BCD] = &ConfigParser::handle_on_set_bcd;
+	process_functions[TOKEN_ENCODER_INC] = &ConfigParser::handle_on_encoder_inc_or_dec;
+	process_functions[TOKEN_ENCODER_DEC] = &ConfigParser::handle_on_encoder_inc_or_dec;
+	process_functions[TOKEN_SERIAL] = &ConfigParser::handle_on_fip_serial;
+	process_functions[TOKEN_FIP_OFFSET_X] = &ConfigParser::handle_on_fip_offset;
+	process_functions[TOKEN_FIP_OFFSET_Y] = &ConfigParser::handle_on_fip_offset;
+	process_functions[TOKEN_FIP_ROTATION] = &ConfigParser::handle_on_fip_rotation;
+	process_functions[TOKEN_FIP_MASK] = &ConfigParser::handle_on_fip_mask;
+	process_functions[TOKEN_FIP_TEXT] = &ConfigParser::handle_on_fip_text;
 }
 
-Configparser::~Configparser()
+ConfigParser::~ConfigParser()
 {
 	process_functions.clear();
 }
 
-std::vector<std::string> Configparser::tokenize(std::string line)
+std::vector<std::string> ConfigParser::tokenize(std::string line)
 {
 	std::regex regex("[:|,]+");
 	std::sregex_token_iterator iter(line.begin(), line.end(), regex, -1);
@@ -58,7 +58,7 @@ std::vector<std::string> Configparser::tokenize(std::string line)
 	return tokens;
 }
 
-bool Configparser::get_and_remove_token_pair(std::vector<std::string>& tokens, std::string name, std::string& out_value)
+bool ConfigParser::get_and_remove_token_pair(std::vector<std::string>& tokens, std::string name, std::string& out_value)
 {
 	for (size_t i = 0; i < tokens.size(); i += 2)
 	{
@@ -72,7 +72,7 @@ bool Configparser::get_and_remove_token_pair(std::vector<std::string>& tokens, s
 	return false;
 }
 
-int Configparser::parse_file(std::string file_name, Configuration& config)
+int ConfigParser::parse_file(std::string file_name, Configuration& config)
 {
 	last_error_message = "";
 	std::ifstream input_file(file_name);
@@ -108,7 +108,7 @@ int Configparser::parse_file(std::string file_name, Configuration& config)
 	return (error_count == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
 }
 
-int Configparser::process_ini_section(IniFileSection& section, Configuration& config)
+int ConfigParser::process_ini_section(IniFileSection& section, Configuration& config)
 {
 	if (section.header.name == TOKEN_SECTION_DEVICE)
 	{
@@ -220,7 +220,7 @@ int Configparser::process_ini_section(IniFileSection& section, Configuration& co
 	return EXIT_SUCCESS;
 }
 
-int Configparser::process_fip_layer_section(IniFileSection& section, Configuration& config)
+int ConfigParser::process_fip_layer_section(IniFileSection& section, Configuration& config)
 {
 	if (section.header.properties.count(TOKEN_IMAGE) > 0)
 	{
@@ -294,7 +294,7 @@ int Configparser::process_fip_layer_section(IniFileSection& section, Configurati
 	return EXIT_SUCCESS;
 }
 
-int Configparser::handle_on_vid(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
+int ConfigParser::handle_on_vid(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
 {
 	(void)section_header;
 	(void)key;
@@ -306,7 +306,7 @@ int Configparser::handle_on_vid(IniFileSectionHeader section_header, std::string
 	return EXIT_SUCCESS;
 }
 
-int Configparser::handle_on_pid(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
+int ConfigParser::handle_on_pid(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
 {
 	(void)section_header;
 	(void)key;
@@ -318,7 +318,7 @@ int Configparser::handle_on_pid(IniFileSectionHeader section_header, std::string
 	return EXIT_SUCCESS;
 }
 
-int Configparser::handle_on_log_level(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
+int ConfigParser::handle_on_log_level(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
 {
 	(void)key;
 	(void)config;
@@ -347,7 +347,7 @@ int Configparser::handle_on_log_level(IniFileSectionHeader section_header, std::
 	return EXIT_SUCCESS;
 }
 
-int Configparser::handle_on_acf_file(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
+int ConfigParser::handle_on_acf_file(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
 {
 	(void)key;
 	if (section_header.id != "")
@@ -359,7 +359,7 @@ int Configparser::handle_on_acf_file(IniFileSectionHeader section_header, std::s
 	return EXIT_SUCCESS;
 }
 
-int Configparser::handle_on_script_file(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
+int ConfigParser::handle_on_script_file(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
 {
 	(void)key;
 	if (section_header.id != "")
@@ -374,7 +374,7 @@ int Configparser::handle_on_script_file(IniFileSectionHeader section_header, std
    from teh string and the parsed index is set in the index variable.
    If no index found index will be set to -1
 */
-void Configparser::check_and_get_array_index(std::string& dataref, int& index)
+void ConfigParser::check_and_get_array_index(std::string& dataref, int& index)
 {
 	std::cmatch m;
 	if (std::regex_match(dataref.c_str(), m, std::regex("(.+)\\[([0-9]+)\\]")))
@@ -388,7 +388,7 @@ void Configparser::check_and_get_array_index(std::string& dataref, int& index)
 	}
 }
 
-XPLMDataTypeID Configparser::normalize_dataref_type(XPLMDataTypeID data_ref_type)
+XPLMDataTypeID ConfigParser::normalize_dataref_type(XPLMDataTypeID data_ref_type)
 {
 	/* from xplane documenation:
 	   Data types each take a bit field; it is legal to have a single dataref 
@@ -407,7 +407,7 @@ XPLMDataTypeID Configparser::normalize_dataref_type(XPLMDataTypeID data_ref_type
 		return data_ref_type;
 }
 
-int Configparser::handle_on_push_or_release(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
+int ConfigParser::handle_on_push_or_release(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
 {
 	Action* action;
 
@@ -551,7 +551,7 @@ int Configparser::handle_on_push_or_release(IniFileSectionHeader section_header,
 	return EXIT_SUCCESS;
 }
 
-int Configparser::handle_on_dynamic_speed(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
+int ConfigParser::handle_on_dynamic_speed(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
 {
 	(void)section_header;
 	(void)config;
@@ -582,7 +582,7 @@ int Configparser::handle_on_dynamic_speed(IniFileSectionHeader section_header, s
 	}
 }
 
-int Configparser::handle_on_lit_or_unlit_or_blink(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
+int ConfigParser::handle_on_lit_or_unlit_or_blink(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
 {
 	//trigger_unlit="dataref:sim/custom/lights/button/absu_zk:0"
 	//trigger_lit="lua:get_led_status():1"
@@ -636,7 +636,7 @@ int Configparser::handle_on_lit_or_unlit_or_blink(IniFileSectionHeader section_h
 	return EXIT_SUCCESS;
 }
 
-int Configparser::handle_on_line_add(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
+int ConfigParser::handle_on_line_add(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
 {
 	(void)key;
 	//line="on_select:SW_ALT,dataref:sim/custom/gauges/compas/pkp_helper_course_L"
@@ -776,7 +776,7 @@ int Configparser::handle_on_line_add(IniFileSectionHeader section_header, std::s
 	return EXIT_FAILURE;
 }
 
-int Configparser::handle_on_set_bcd(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
+int ConfigParser::handle_on_set_bcd(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
 {
 	(void)key;
 	if (section_header.name == TOKEN_SECTION_MULTI_DISPLAY)
@@ -792,7 +792,7 @@ int Configparser::handle_on_set_bcd(IniFileSectionHeader section_header, std::st
 	return EXIT_SUCCESS;
 }
 
-int Configparser::handle_on_encoder_inc_or_dec(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
+int ConfigParser::handle_on_encoder_inc_or_dec(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
 {
 	//on_increment="commandref:sim/GPS/g1000n1_nav_inner_up:once"
 	//on_decrement = "commandref:sim/GPS/g1000n1_nav_inner_down:once"
@@ -885,7 +885,7 @@ int Configparser::handle_on_encoder_inc_or_dec(IniFileSectionHeader section_head
 	return EXIT_SUCCESS;
 }
 
-int Configparser::handle_on_fip_serial(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
+int ConfigParser::handle_on_fip_serial(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
 {
 	(void)section_header;
 	(void)key;
@@ -894,7 +894,7 @@ int Configparser::handle_on_fip_serial(IniFileSectionHeader section_header, std:
 	return EXIT_SUCCESS;
 }
 
-int Configparser::handle_on_fip_offset(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
+int ConfigParser::handle_on_fip_offset(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
 {
 	//offset_x="const:80"
 	//offset_y = "dataref::sim/cockpit2/radios/actuators/com1_frequency_hz"
@@ -959,7 +959,7 @@ int Configparser::handle_on_fip_offset(IniFileSectionHeader section_header, std:
 	return EXIT_SUCCESS;
 }
 
-int Configparser::handle_on_fip_rotation(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
+int ConfigParser::handle_on_fip_rotation(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
 {
 	(void)key;
 	ScreenAction* action = new ScreenAction();
@@ -1008,7 +1008,7 @@ int Configparser::handle_on_fip_rotation(IniFileSectionHeader section_header, st
 	return EXIT_SUCCESS;
 }
 
-int Configparser::handle_on_fip_mask(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
+int ConfigParser::handle_on_fip_mask(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
 {
 	(void)section_header;
 	(void)key;
@@ -1051,7 +1051,7 @@ int Configparser::handle_on_fip_mask(IniFileSectionHeader section_header, std::s
 	return EXIT_SUCCESS;
 }
 
-int Configparser::handle_on_fip_text(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
+int ConfigParser::handle_on_fip_text(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config)
 {
 	(void)key;
 	int page_index = config.class_configs.back().fip_screens[last_device_id]->get_last_page_index();

--- a/src/core/ConfigParser.h
+++ b/src/core/ConfigParser.h
@@ -10,10 +10,10 @@
 #include "Configuration.h"
 #include "IniFileParser.h"
 
-class Configparser
+class ConfigParser
 {
 private:
-	typedef int (Configparser::* f_handle_on_key_value)(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config);
+	typedef int (ConfigParser::* f_handle_on_key_value)(IniFileSectionHeader section_header, std::string key, std::string value, Configuration& config);
 
 	std::map<std::string, f_handle_on_key_value> process_functions;
 	std::vector<std::string> tokenize(std::string line);
@@ -107,7 +107,7 @@ private:
 	float speed_high = 0;
 	int multi_high = 1;
 public:
-	Configparser();
-	~Configparser();
+	ConfigParser();
+	~ConfigParser();
 	int parse_file(std::string file_name, Configuration& config);
 };

--- a/src/core/Configuration.cpp
+++ b/src/core/Configuration.cpp
@@ -129,23 +129,28 @@ ClassConfiguration& ClassConfiguration::operator=(const ClassConfiguration& othe
 void ClassConfiguration::clear()
 {
 	for (auto &act : push_actions)
-		act.second.clear();
+    	for (auto *a : act.second)
+        	delete a;
 	push_actions.clear();
 
 	for (auto &act : release_actions)
-		act.second.clear();
+		for (auto *a : act.second)
+			delete a;
 	release_actions.clear();
 
 	for (auto &act : encoder_inc_actions)
-		act.second.clear();
+		for (auto *a : act.second)
+			delete a;
 	encoder_inc_actions.clear();
 
 	for (auto &act : encoder_dec_actions)
-		act.second.clear();
+		for (auto *a : act.second)
+			delete a;
 	encoder_dec_actions.clear();
 
 	for (auto &act : light_triggers)
-		act.second.clear();
+		for (auto *a : act.second)
+			delete a;
 	light_triggers.clear();
 
 	for (auto& scr : fip_screens)

--- a/src/core/Configuration.cpp
+++ b/src/core/Configuration.cpp
@@ -89,6 +89,8 @@ ClassConfiguration& ClassConfiguration::operator=(const ClassConfiguration& othe
 	if (this == &other)
 		return *this;
 
+	clear();
+
 	device_class_type = other.device_class_type;
 	pid = other.pid;
 	vid = other.vid;

--- a/src/core/Device.h
+++ b/src/core/Device.h
@@ -9,13 +9,11 @@
 #include <map>
 #include <list>
 #include <thread>
-#include "Action.h"
 #include "Configuration.h"
 #include <queue>
 #include "Action.h"
 #include <thread>
 #include <chrono>
-using namespace std::literals;
 
 struct PanelButton
 {

--- a/src/core/GenericDisplay.cpp
+++ b/src/core/GenericDisplay.cpp
@@ -141,7 +141,7 @@ void GenericDisplay::evaluate_and_store_dataref_value()
 		if (const_value > DBL_MIN)
 			display_value = const_value;
 		else if (!lua_function.empty())
-			LuaHelper::get_instace()->do_string("return " + lua_function, display_value);
+			LuaHelper::get_instance()->do_string("return " + lua_function, display_value);
 		break;
 	}
 	if (abs(display_value - display_value_old) >= 0.001)

--- a/src/core/GenericDisplay.cpp
+++ b/src/core/GenericDisplay.cpp
@@ -116,7 +116,7 @@ void GenericDisplay::add_lua(std::string _lua_function)
 /* call this function only from XPlane flight loop */
 void GenericDisplay::evaluate_and_store_dataref_value()
 {
-	guard.lock();
+	std::lock_guard<std::mutex> lock(guard);
 	switch (data_ref_type) {
 	case xplmType_Int:
 		display_value = (double)XPLMGetDatai(condition);
@@ -144,8 +144,6 @@ void GenericDisplay::evaluate_and_store_dataref_value()
 			LuaHelper::get_instace()->do_string("return " + lua_function, display_value);
 		break;
 	}
-	guard.unlock();
-
 	if (abs(display_value - display_value_old) >= 0.001)
 		display_value_changed = true;
 

--- a/src/core/Logger.h
+++ b/src/core/Logger.h
@@ -33,19 +33,17 @@ public:
 
 	static std::size_t number_of_stored_messages()
 	{
-		guard.lock();
+		std::lock_guard<std::mutex> lock(guard);
 		std::size_t number_of_messages = saved_errors_and_warnings.size();
-		guard.unlock();
 
 		return number_of_messages;
 	}
 
 	static std::list<std::string> get_and_clear_stored_messages()
 	{
-		guard.lock();
+		std::lock_guard<std::mutex> lock(guard);
 		std::list<std::string> messages = saved_errors_and_warnings;
 		saved_errors_and_warnings.clear();
-		guard.unlock();
 
 		return messages;
 	}
@@ -85,9 +83,8 @@ public:
 
 			if (last_message_log_level == TLogLevel::logERROR || last_message_log_level == TLogLevel::logWARNING)
 			{
-				guard.lock();
+				std::lock_guard<std::mutex> lock(guard);
 				Logger::saved_errors_and_warnings.push_back(log_level_str + str());
-				guard.unlock();
 			}
 		}
 	}

--- a/src/core/LuaHelper.cpp
+++ b/src/core/LuaHelper.cpp
@@ -81,7 +81,7 @@ extern "C" {
 		}
 
 		std::string dataref_str = lua_tostring(L, 1);
-		XPLMDataRef dataref = LuaHelper::get_instace()->get_dataref(dataref_str);
+		XPLMDataRef dataref = LuaHelper::get_instance()->get_dataref(dataref_str);
 		if (dataref == NULL)
 		{
 			Logger(TLogLevel::logERROR) << "Lua get: invalid dataref :" << dataref_str << std::endl;
@@ -93,7 +93,7 @@ extern "C" {
 			dataref_array_index = lua_tointeger(L, 2);
 		}
 
-		XPLMDataTypeID dataref_type = LuaHelper::get_instace()->get_dataref_type(dataref);
+		XPLMDataTypeID dataref_type = LuaHelper::get_instance()->get_dataref_type(dataref);
 		int value_ia = 0;
 		float value_fa = 0;
 
@@ -138,14 +138,14 @@ extern "C" {
 		}
 
 		std::string dataref_str = lua_tostring(L, 1);
-		XPLMDataRef dataref = LuaHelper::get_instace()->get_dataref(dataref_str);
+		XPLMDataRef dataref = LuaHelper::get_instance()->get_dataref(dataref_str);
 		if (dataref == NULL)
 		{
 			Logger(TLogLevel::logERROR) << "lua set: invalid dataref: " << dataref_str << std::endl;
 			return 0;
 		}
 
-		XPLMDataTypeID dataref_type = LuaHelper::get_instace()->get_dataref_type(dataref);
+		XPLMDataTypeID dataref_type = LuaHelper::get_instance()->get_dataref_type(dataref);
 		switch (dataref_type)
 		{
 		case xplmType_Int:
@@ -217,7 +217,7 @@ extern "C" {
 		int pid = (int)lua_tonumber(L, 2);
 		std::string button_name = lua_tostring(L, 3);
 
-		int state = LuaHelper::get_instace()->get_button_state(vid, pid, button_name);
+		int state = LuaHelper::get_instance()->get_button_state(vid, pid, button_name);
 
 		std::string button_state_str = "";
 
@@ -253,7 +253,7 @@ extern "C" {
 		int pid = (int)lua_tonumber(L, 2);
 		std::string light_name = lua_tostring(L, 3);
 
-		TriggerType state = LuaHelper::get_instace()->get_light_state(vid, pid, light_name);
+		TriggerType state = LuaHelper::get_instance()->get_light_state(vid, pid, light_name);
 
 		if (state == TriggerType::UNKNOWN)
 		{
@@ -287,7 +287,7 @@ LuaHelper::LuaHelper()
 	lua_enabled = false;
 }
 
-LuaHelper* LuaHelper::get_instace()
+LuaHelper* LuaHelper::get_instance()
 {
 	if (instance == NULL)
 		instance = new LuaHelper();

--- a/src/core/LuaHelper.h
+++ b/src/core/LuaHelper.h
@@ -19,7 +19,7 @@
 class LuaHelper
 {
 public:
-	static LuaHelper* get_instace();
+	static LuaHelper* get_instance();
 	int init();
 	void close();
 	void push_global_string(std::string name, std::string value);

--- a/src/core/Trigger.cpp
+++ b/src/core/Trigger.cpp
@@ -68,21 +68,17 @@ void Trigger::evaluate_and_store_action()
 		LuaHelper::get_instace()->do_string("return " + lua_str,act_value);
 	}
 
-	guard.lock();
-
+	std::lock_guard<std::mutex> lock(guard);
 	if (abs(act_value - trigger_value) <= 0.001 && abs(last_value - act_value) >= 0.01)
 		stored_action = trigger_action;
-
-	guard.unlock();
 
 	last_value = act_value;
 }
 
 TriggerType Trigger::get_and_clear_stored_action()
 {
-	guard.lock();
+	std::lock_guard<std::mutex> lock(guard);
 	TriggerType _stored = stored_action;
 	stored_action = TriggerType::NO_CHANGE;
-	guard.unlock();
 	return _stored;
 }

--- a/src/core/Trigger.cpp
+++ b/src/core/Trigger.cpp
@@ -65,7 +65,7 @@ void Trigger::evaluate_and_store_action()
 	}
 	else
 	{
-		LuaHelper::get_instace()->do_string("return " + lua_str,act_value);
+		LuaHelper::get_instance()->do_string("return " + lua_str,act_value);
 	}
 
 	std::lock_guard<std::mutex> lock(guard);

--- a/src/core/UsbHidDevice.cpp
+++ b/src/core/UsbHidDevice.cpp
@@ -10,6 +10,8 @@
 #include "UsbHidDevice.h"
 #include "Logger.h"
 
+using namespace std::literals;
+
 int UsbHidDevice::ref_count = 0;
 bool UsbHidDevice::hid_api_initialized = false;
 

--- a/src/core/XPanel.cpp
+++ b/src/core/XPanel.cpp
@@ -278,11 +278,21 @@ int enumerate_and_add_hid_devices(ClassConfiguration& it)
 	do
 	{		
 		Logger(TLogLevel::logDEBUG) << "add new panel device. vid =" << it.vid << " pid = " << it.pid << std::endl;
+		hid_device* hid_dev = hid_open_path(dev_info->path);
+		if (hid_dev == NULL)
+		{
+			Logger(TLogLevel::logERROR) << "error opening hid device with vid=" << it.vid << " pid=" << it.pid << std::endl;
+			continue;
+		}
+
+		if (hid_set_nonblocking(hid_dev, 1) != 0)
+		{
+			Logger(TLogLevel::logERROR) << "error hid_set_nonblocking with vid=" << it.vid << " pid=" << it.pid << std::endl;
+			continue;
+		}
+
 		device = new T(it);
 		devices.push_back(device);
-
-		hid_device* hid_dev = hid_open_path(dev_info->path);
-		hid_set_nonblocking(hid_dev, 1);
 		((T*)device)->connect(hid_dev);
 		device->start();
 		device->thread_handle = new std::thread(&T::thread_func, (T*)device);

--- a/src/core/XPanel.cpp
+++ b/src/core/XPanel.cpp
@@ -236,7 +236,7 @@ std::filesystem::path find_config_file(const std::string& aircraft_file_name, co
 		{
 			if (entry.is_regular_file() && entry.path().extension() == ".ini")
 			{
-				Configparser temp_parser;
+				ConfigParser temp_parser;
 				Configuration temp_config;
 				if (temp_parser.parse_file(entry.path().string(), temp_config) == EXIT_SUCCESS)
 				{
@@ -320,7 +320,7 @@ int init_and_start_xpanel_plugin(void)
 	config.aircraft_path = aircraft_file_path;
 	Logger(TLogLevel::logINFO) << "aircraft path: " << config.aircraft_path << std::endl;
 
-	Configparser p;
+	ConfigParser p;
 	int result = p.parse_file(init_path.string(), config);
 	if (result != EXIT_SUCCESS)
 	{

--- a/src/core/XPanel.cpp
+++ b/src/core/XPanel.cpp
@@ -156,7 +156,7 @@ float flight_loop_callback(float, float, int, void*)
 	}
 
 	// execute lua scrip defined flight_loop function
-	LuaHelper::get_instace()->do_flight_loop();
+	LuaHelper::get_instance()->do_flight_loop();
 
 	// process button push/release events
 	ActionQueue::get_instance()->activate_actions_in_queue();
@@ -181,7 +181,7 @@ float error_display_callback(float, float, int, void*)
 void stop_and_clear_xpanel_plugin()
 {
 	XPLMUnregisterFlightLoopCallback(flight_loop_callback, NULL);
-	LuaHelper::get_instace()->close();
+	LuaHelper::get_instance()->close();
 
 	for (auto& dev : devices)
 	{
@@ -286,7 +286,7 @@ int enumerate_and_add_hid_devices(ClassConfiguration& it)
 		((T*)device)->connect(hid_dev);
 		device->start();
 		device->thread_handle = new std::thread(&T::thread_func, (T*)device);
-		LuaHelper::get_instace()->register_hid_device((UsbHidDevice*)device);
+		LuaHelper::get_instance()->register_hid_device((UsbHidDevice*)device);
 		dev_info = dev_info->next;
 	} while (dev_info);
 	hid_free_enumeration(dev_info_first);
@@ -334,12 +334,12 @@ int init_and_start_xpanel_plugin(void)
 		Logger(TLogLevel::logWARNING) << "Config was created for another aircraft (" << config.aircraft_acf << "). Current is " << aircraft_file_name << std::endl;
 	}
 
-	LuaHelper::get_instace()->init();
-	LuaHelper::get_instace()->push_global_string("AIRCRAFT_FILENAME", aircraft_file_name);
-	LuaHelper::get_instace()->push_global_string("AIRCRAFT_PATH", aircraft_file_path);
-	LuaHelper::get_instace()->push_global_string("PLUGIN_VERSION", PLUGIN_VERSION);
-	LuaHelper::get_instace()->push_global_string("PLUGIN_SIGNATURE", PLUGIN_SIGNATURE);
-	LuaHelper::get_instace()->push_global_string("PLUGIN_CONFIG_FILE", init_path.string());
+	LuaHelper::get_instance()->init();
+	LuaHelper::get_instance()->push_global_string("AIRCRAFT_FILENAME", aircraft_file_name);
+	LuaHelper::get_instance()->push_global_string("AIRCRAFT_PATH", aircraft_file_path);
+	LuaHelper::get_instance()->push_global_string("PLUGIN_VERSION", PLUGIN_VERSION);
+	LuaHelper::get_instance()->push_global_string("PLUGIN_SIGNATURE", PLUGIN_SIGNATURE);
+	LuaHelper::get_instance()->push_global_string("PLUGIN_CONFIG_FILE", init_path.string());
 
 	std::filesystem::path script_path;
 	if (config.script_file != "")
@@ -355,13 +355,13 @@ int init_and_start_xpanel_plugin(void)
 
 	if (std::filesystem::exists(script_path))
 	{
-		if (LuaHelper::get_instace()->load_script_file(script_path.string()) != EXIT_SUCCESS)
+		if (LuaHelper::get_instance()->load_script_file(script_path.string()) != EXIT_SUCCESS)
 		{
 			stop_and_clear_xpanel_plugin();
 			Logger(TLogLevel::logERROR) << "Error loading Lua script: " << config.script_file << std::endl;
 			return EXIT_FAILURE;
 		}
-		LuaHelper::get_instace()->push_global_string("SCRIPT_PATH", script_path.string());
+		LuaHelper::get_instance()->push_global_string("SCRIPT_PATH", script_path.string());
 	}
 
 	Device* device;

--- a/src/devices/fip/FIPDevice.cpp
+++ b/src/devices/fip/FIPDevice.cpp
@@ -8,6 +8,8 @@
 #include "core/Logger.h"
 #include "FIPDevice.h"
 
+using namespace std::literals;
+
 FIPDevice::FIPDevice(ClassConfiguration& _config) :Device(_config,2,1)
 {
 	f_device = NULL;

--- a/src/devices/fip/FIPScreen.cpp
+++ b/src/devices/fip/FIPScreen.cpp
@@ -87,7 +87,7 @@ void FIPScreen::evaluate_and_store_screen_action()
 
 		//Logger(logTRACE) << "FIP screen: value changed (page " << action->page_index << " layer " << action->layer_index << "): " << action_value << std::endl;
 
-		guard.lock();
+		std::lock_guard<std::mutex> lock(guard);
 		switch (action->type) {
 		case SC_ROTATION:
 			rotate_layer(action->page_index, action->layer_index, action_value);
@@ -104,7 +104,6 @@ void FIPScreen::evaluate_and_store_screen_action()
 		default:
 			Logger(logERROR) << "FIP screen: unknown action type" << std::endl;
 		}
-		guard.unlock();
 	}
 }
 
@@ -201,8 +200,7 @@ void FIPScreen::render_page(int page_index, void** byte_buffer)
 	if (pages.count(page_index) == 0)
 		return;
 
-	guard.lock();
+	std::lock_guard<std::mutex> lock(guard);
 	pages[page_index]->render_page();
 	*byte_buffer = pages[page_index]->get_raw_buffer();
-	guard.unlock();
 }

--- a/src/devices/fip/FIPScreen.cpp
+++ b/src/devices/fip/FIPScreen.cpp
@@ -60,12 +60,12 @@ void FIPScreen::evaluate_and_store_screen_action()
 		{
 			if (action->type == SC_SET_TEXT)
 			{
-				LuaHelper::get_instace()->do_string("return " + action->lua_str, action_value_str);
+				LuaHelper::get_instance()->do_string("return " + action->lua_str, action_value_str);
 			}
 			else
 			{
 				double ret_value = 0;
-				LuaHelper::get_instace()->do_string("return " + action->lua_str, ret_value);
+				LuaHelper::get_instance()->do_string("return " + action->lua_str, ret_value);
 				action_value = (int)ret_value;
 			}
 		}

--- a/src/devices/trc-1000/TRC1000.cpp
+++ b/src/devices/trc-1000/TRC1000.cpp
@@ -9,6 +9,8 @@
 
 #define TRC1000_READ_TIMEOUT_MILLISEC 50
 
+using namespace std::literals;
+
 TRC1000::TRC1000(ClassConfiguration& config, int _read_buffer_size, int _write_buffer_size) :UsbHidDevice(config, _read_buffer_size, _write_buffer_size)
 {
 	read_buffer_size = _read_buffer_size;

--- a/test/mock_hid_api.cpp
+++ b/test/mock_hid_api.cpp
@@ -9,18 +9,25 @@
 #include <sstream>
 #include <iostream>
 #include <cstring>
+#include <chrono>
 
 #ifndef WIN32
 #define _strdup strdup
 #endif
+#include <thread>
+
+using namespace std::literals;
 
 int device = 123;
 int vid = 0;
 int pid = 0;
 bool hid_device_open = false;
+std::atomic<bool> hid_read_event_done = false;
+std::atomic<bool> hid_write_event_done = false;
 
 extern int HID_API_EXPORT HID_API_CALL hid_init()
 {
+	hid_read_event_done.store(false);
 	hid_device_open = false;
 	return 0;
 }
@@ -84,11 +91,34 @@ unsigned char mock_read_buffer[256];
 void test_hid_mock_init()
 {
 	memset(mock_read_buffer, 0, sizeof(mock_read_buffer));
+	hid_read_event_done.store(false);
 }
 
+/// @brief Set the read data for the next call to hid_read(). This is used in the unit tests to simulate the data that would be read from the HID device.
+/// @param data 
+/// @param length 
 void test_hid_set_read_data(unsigned char* data, size_t length)
 {
 	memcpy(mock_read_buffer, data, length);
+	hid_read_event_done.store(false);
+}
+
+/// @brief Wait for the hid_read() to be called and the data to be read from the mock buffer. This is used in the unit tests to ensure that the data has been processed before checking the results.
+/// @param timeout_milliseconds
+/// @return true if the data has been read, false if the timeout has expired
+bool test_hid_read_wait_for_event(int timeout_milliseconds)
+{
+	std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+	timeout_milliseconds = timeout_milliseconds < 0 ? 0 : (int)timeout_milliseconds/10;
+
+	do
+	{
+		std::this_thread::sleep_for(std::chrono::milliseconds(10));
+		timeout_milliseconds--;
+	} while (!hid_read_event_done.load() && timeout_milliseconds > 0);
+
+	return hid_read_event_done.load();
 }
 
 extern int HID_API_EXPORT HID_API_CALL hid_read(hid_device* device, unsigned char* data, size_t length)
@@ -100,6 +130,7 @@ extern int HID_API_EXPORT HID_API_CALL hid_read(hid_device* device, unsigned cha
 	}
 
 	memcpy(data, mock_read_buffer, length);
+	hid_read_event_done.store(true);
 	return length;
 }
 
@@ -125,6 +156,8 @@ extern int HID_API_EXPORT HID_API_CALL hid_send_feature_report(hid_device* devic
 		return -1;
 
 	memcpy(mock_write_buffer, data, length);
+	hid_write_event_done.store(true);
+
 	return length;
 }
 
@@ -139,9 +172,28 @@ HID_API_EXPORT const wchar_t* HID_API_CALL hid_error(hid_device* device)
 	return NULL;
 }
 
+bool test_hid_write_wait_for_event(int timeout_milliseconds)
+{
+	timeout_milliseconds = timeout_milliseconds < 0 ? 0 : (int)timeout_milliseconds/10;
+
+	do
+	{
+		std::this_thread::sleep_for(std::chrono::milliseconds(10));
+		timeout_milliseconds--;
+	} while (!hid_write_event_done.load() && timeout_milliseconds > 0);
+
+	return hid_write_event_done.load();
+}
+
+/// @brief Read the data that was written to the mock HID device. This is used in the unit tests to verify that the correct data was sent to the device.
+/// @param data 
+/// @param length 
 void test_hid_get_write_data(unsigned char* data, size_t length)
 {
+	test_hid_write_wait_for_event(300);
+
 	memcpy(data, mock_write_buffer, length);
+	hid_write_event_done.store(false);
 }
 
 int test_hid_get_vid()

--- a/test/test_FIP.cpp
+++ b/test/test_FIP.cpp
@@ -11,9 +11,11 @@
 #include "core/LuaHelper.h"
 #include "CppUnitTest.h"
 #include "fip/FIPDevice.h"
-#include "core/Configparser.h"
+#include "core/ConfigParser.h"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace std::literals;
+
 void test_set_aircraft_path_and_filename(char* file_name, char* path);
 int test_fip_get_led_state(int led_index);
 void test_fip_set_button_states(uint16_t _button_states);

--- a/test/test_FIP.cpp
+++ b/test/test_FIP.cpp
@@ -43,8 +43,8 @@ namespace test
 			int result = p->parse_file("../../test/test-fip-screen-config.ini", config);
 			Assert::AreEqual(0, result);
 
-			LuaHelper::get_instace()->init();
-			LuaHelper::get_instace()->load_script_file("../../test/" + config.script_file);
+			LuaHelper::get_instance()->init();
+			LuaHelper::get_instance()->load_script_file("../../test/" + config.script_file);
 
 			fip_device = new FIPDevice(config.class_configs[0]);
 			fip_device->connect();

--- a/test/test_FIP.cpp
+++ b/test/test_FIP.cpp
@@ -29,7 +29,7 @@ namespace test
 	{
 	private:
 		Configuration config;
-		Configparser* p;
+		ConfigParser* p;
 		FIPDevice* fip_device;
 		std::thread* t;
 		std::string airspeed_dataref_str = "sim/cockpit2/gauges/indicators/airspeed_kts_pilot";
@@ -39,7 +39,7 @@ namespace test
 		{
 			test_set_aircraft_path_and_filename("test.acf", "./");
 
-			p = new Configparser();
+			p = new ConfigParser();
 			int result = p->parse_file("../../test/test-fip-screen-config.ini", config);
 			Assert::AreEqual(0, result);
 

--- a/test/test_arduino_home.cpp
+++ b/test/test_arduino_home.cpp
@@ -32,7 +32,7 @@ namespace test
 	{
 	private:
 		Configuration config;
-		Configparser* p;
+		ConfigParser* p;
 		ArduinoHomeCockpit* device;
 		std::thread* t;
 	public:
@@ -40,7 +40,7 @@ namespace test
 		{
 			if (p == NULL) 
 			{
-				p = new Configparser();
+				p = new ConfigParser();
 				int result = p->parse_file("../../test/test-arduino-home.ini", config);
 				Assert::AreEqual(0, result);
 				device = new ArduinoHomeCockpit(config.class_configs[0]);

--- a/test/test_arduino_home.cpp
+++ b/test/test_arduino_home.cpp
@@ -17,6 +17,7 @@
 #include "core/Logger.h"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace std::literals;
 
 void test_hid_set_read_data(unsigned char* data, size_t length);
 int test_get_dataref_value(const char* datarefstr);

--- a/test/test_config_parser.cpp
+++ b/test/test_config_parser.cpp
@@ -22,11 +22,11 @@ namespace test
 	{
 	private:
 		Configuration config;
-		Configparser* p;
+		ConfigParser* p;
 	public:
 		TEST_METHOD_INITIALIZE(TestConfigParserInit)
 		{
-			p = new Configparser();
+			p = new ConfigParser();
 			int result = p->parse_file("../../test/test-valid-config.ini", config);
 			Assert::AreEqual(0, result);
 		}

--- a/test/test_dynamic_speed.cpp
+++ b/test/test_dynamic_speed.cpp
@@ -63,7 +63,7 @@ namespace test
 			int result = p->parse_file("../../test/test-dynamic-speed.ini", config);
 			Assert::AreEqual(0, result);
 
-			LuaHelper::get_instace()->init();
+			LuaHelper::get_instance()->init();
 
 			device = new SaitekMultiPanel(config.class_configs[0]);
 			device->connect();

--- a/test/test_dynamic_speed.cpp
+++ b/test/test_dynamic_speed.cpp
@@ -50,7 +50,7 @@ namespace test
 	{
 	private:
 		Configuration config;
-		Configparser* p;
+		ConfigParser* p;
 		SaitekMultiPanel* device;
 		std::thread* t;
 		std::string dataref_str = "test/dynamic_speed_test";
@@ -59,7 +59,7 @@ namespace test
 		{
 			test_hid_mock_init();
 
-			p = new Configparser();
+			p = new ConfigParser();
 			int result = p->parse_file("../../test/test-dynamic-speed.ini", config);
 			Assert::AreEqual(0, result);
 

--- a/test/test_dynamic_speed.cpp
+++ b/test/test_dynamic_speed.cpp
@@ -16,6 +16,7 @@
 #include "core/ConfigParser.h"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace std::literals;
 
 void test_hid_set_read_data(unsigned char* data, size_t length);
 int test_get_dataref_value(const char* datarefstr);

--- a/test/test_generic_display.cpp
+++ b/test/test_generic_display.cpp
@@ -16,6 +16,7 @@
 #include "core/ConfigParser.h"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace std::literals;
 
 void test_hid_set_read_data(unsigned char* data, size_t length);
 int test_get_dataref_value(const char* datarefstr);

--- a/test/test_generic_display.cpp
+++ b/test/test_generic_display.cpp
@@ -31,14 +31,14 @@ namespace test
 	TEST_CLASS(test_generic_display)
 	{
 	private:		
-		Configparser* p;
+		ConfigParser* p;
 		ArduinoHomeCockpit* device;
 		std::thread* t;
 	public:
 		TEST_METHOD_INITIALIZE(TestGenericDisplayInit)
 		{
 			Configuration config;
-			p = new Configparser();
+			p = new ConfigParser();
 			int result = p->parse_file("../../test/test-arduino-home.ini", config);
 			Assert::AreEqual(0, result);
 

--- a/test/test_generic_display.cpp
+++ b/test/test_generic_display.cpp
@@ -42,8 +42,8 @@ namespace test
 			int result = p->parse_file("../../test/test-arduino-home.ini", config);
 			Assert::AreEqual(0, result);
 
-			LuaHelper::get_instace()->init();
-			LuaHelper::get_instace()->load_script_file("../../test/" + config.script_file);
+			LuaHelper::get_instance()->init();
+			LuaHelper::get_instance()->load_script_file("../../test/" + config.script_file);
 
 			device = new ArduinoHomeCockpit(config.class_configs[0]);
 			device->connect();

--- a/test/test_lua.cpp
+++ b/test/test_lua.cpp
@@ -29,30 +29,30 @@ namespace test
 	public:
 		TEST_METHOD_INITIALIZE(TestLuaInit)
 		{
-			LuaHelper::get_instace()->init();
+			LuaHelper::get_instance()->init();
 		}
 
 		TEST_METHOD(TestLuaDoString)
 		{
-			LuaHelper::get_instace()->do_string("command_once(\"/sim/test\")");
+			LuaHelper::get_instance()->do_string("command_once(\"/sim/test\")");
 			Assert::AreEqual("/sim/test_ONCE", test_get_last_command().c_str());
 
-			LuaHelper::get_instace()->do_string("command_begin(\"/sim/test\")");
+			LuaHelper::get_instance()->do_string("command_begin(\"/sim/test\")");
 			Assert::AreEqual("/sim/test_BEGIN", test_get_last_command().c_str());
 
-			LuaHelper::get_instace()->do_string("command_end(\"/sim/test\")");
+			LuaHelper::get_instance()->do_string("command_end(\"/sim/test\")");
 			Assert::AreEqual("/sim/test_END", test_get_last_command().c_str());
 
-			LuaHelper::get_instace()->do_string("set_dataref(\"/sim/test2\",123)");
+			LuaHelper::get_instance()->do_string("set_dataref(\"/sim/test2\",123)");
 			Assert::AreEqual(123, test_get_dataref_value("/sim/test2"));
 
 			test_set_dataref_value("/sim/test3", 321);
-			LuaHelper::get_instace()->do_string("get_dataref(\"/sim/test3\")");
+			LuaHelper::get_instance()->do_string("get_dataref(\"/sim/test3\")");
 		}
 
 		TEST_METHOD(TestLuaLoadScript)
 		{
-			int res = LuaHelper::get_instace()->load_script_file("../../test/test-script.lua");
+			int res = LuaHelper::get_instance()->load_script_file("../../test/test-script.lua");
 			
 			Assert::AreEqual(EXIT_SUCCESS, res);
 
@@ -62,15 +62,15 @@ namespace test
 
 		TEST_METHOD(TestLuaFlightLoop)
 		{
-			LuaHelper::get_instace()->load_script_file("../../test/test-script.lua");
+			LuaHelper::get_instance()->load_script_file("../../test/test-script.lua");
 
-			LuaHelper::get_instace()->do_flight_loop();
+			LuaHelper::get_instance()->do_flight_loop();
 			Assert::AreEqual(12345, test_get_dataref_value("/sim/test/lua_flight_loop"));
 		}
 
 		TEST_METHOD_CLEANUP(TestLuaCleanup)
 		{
-			LuaHelper::get_instace()->close();
+			LuaHelper::get_instance()->close();
 		}
 	};
 }

--- a/test/test_multi_panel.cpp
+++ b/test/test_multi_panel.cpp
@@ -43,14 +43,14 @@ namespace test
 			int result = p->parse_file("../../test/test-valid-config.ini", config);
 			Assert::AreEqual(0, result);
 
-			LuaHelper::get_instace()->init();			
-			LuaHelper::get_instace()->load_script_file("../../test/" + config.script_file);
+			LuaHelper::get_instance()->init();			
+			LuaHelper::get_instance()->load_script_file("../../test/" + config.script_file);
 			
 			device = new SaitekMultiPanel(config.class_configs[0]);
 			device->connect();
 			device->start();
 			t = new std::thread(&SaitekMultiPanel::thread_func, (SaitekMultiPanel*)device);
-			LuaHelper::get_instace()->register_hid_device(device);
+			LuaHelper::get_instance()->register_hid_device(device);
 		}
 
 		TEST_METHOD(Test_VID_PID)
@@ -258,7 +258,7 @@ namespace test
 			std::this_thread::sleep_for(150ms);
 			test_flight_loop(device);
 			double ret_value=0;
-			LuaHelper::get_instace()->do_string("return get_hid_input_status('REV')", ret_value);
+			LuaHelper::get_instance()->do_string("return get_hid_input_status('REV')", ret_value);
 			Assert::AreEqual(1, (int)ret_value);
 			
 			// Release REV button
@@ -266,7 +266,7 @@ namespace test
 			test_hid_set_read_data(buffer, sizeof(buffer));
 			std::this_thread::sleep_for(150ms);
 			test_flight_loop(device);
-			LuaHelper::get_instace()->do_string("return get_hid_input_status('REV')", ret_value);
+			LuaHelper::get_instance()->do_string("return get_hid_input_status('REV')", ret_value);
 			Assert::AreEqual(0, (int)ret_value);
 		}
 

--- a/test/test_multi_panel.cpp
+++ b/test/test_multi_panel.cpp
@@ -16,6 +16,7 @@
 #include "core/ConfigParser.h"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace std::literals;
 
 void test_hid_set_read_data(unsigned char* data, size_t length);
 int test_get_dataref_value(const char* datarefstr);

--- a/test/test_multi_panel.cpp
+++ b/test/test_multi_panel.cpp
@@ -26,6 +26,7 @@ std::string test_get_last_command();
 void test_hid_get_write_data(unsigned char* data, size_t length);
 void test_flight_loop(std::vector<ClassConfiguration> &config);
 void test_flight_loop(Device* dev);
+bool test_hid_read_wait_for_event(int timeout_milliseconds);
 
 namespace test
 {
@@ -64,7 +65,7 @@ namespace test
 		{
 			unsigned char buffer[4] = { 0x80,0,0,0 };
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 			test_flight_loop(device);
 			Assert::AreEqual(1, test_get_dataref_value("/sim/hello/AP"));
 			// this command is called by the lua script:
@@ -72,7 +73,7 @@ namespace test
 
 			buffer[0] = 0;
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 			test_flight_loop(device);
 			Assert::AreEqual(0, test_get_dataref_value("/sim/hello/AP"));
 			// this command is called by the lua script:
@@ -84,14 +85,14 @@ namespace test
 		{
 			unsigned char buffer[4] = { 0,0x02,0,0 };
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 			test_flight_loop(device);
 			std::string last_cmd = test_get_last_command();
 			Assert::AreEqual("/sim/cmd/NAV_BEGIN", last_cmd.c_str());
 
 			memset(buffer, 0, sizeof(buffer));
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 			test_flight_loop(device);
 			last_cmd = test_get_last_command();
 			Assert::AreEqual("/sim/cmd/NAV_END", last_cmd.c_str());
@@ -102,7 +103,7 @@ namespace test
 			int val_before = test_get_dataref_value("sim/custom/switchers/console/absu_pitch_wheel");
 			unsigned char buffer[4] = { 0,0,0x08,0 };
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 			test_flight_loop(device);
 			int val_after = test_get_dataref_value("sim/custom/switchers/console/absu_pitch_wheel");
 
@@ -110,21 +111,21 @@ namespace test
 
 			memset(buffer, 0, sizeof(buffer));
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 		}
 		//Test a button with command once action
 		TEST_METHOD(TestHDGButton)
 		{
 			unsigned char buffer[4] = { 0,0x01,0,0 };
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 			test_flight_loop(device);
 			std::string last_cmd = test_get_last_command();
 			Assert::AreNotEqual("/sim/cmd/HDG_ONCE", last_cmd.c_str());
 
 			memset(buffer, 0, sizeof(buffer));
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 			test_flight_loop(device);
 			last_cmd = test_get_last_command();
 			Assert::AreEqual("/sim/cmd/HDG_ONCE", last_cmd.c_str());
@@ -191,7 +192,7 @@ namespace test
 			// set rotation switch to ALT_SW position
 			unsigned char buffer[4] = { 0x01,0,0,0 };
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 
 			test_flight_loop(device);
 			std::this_thread::sleep_for(150ms);
@@ -223,29 +224,29 @@ namespace test
 			// set rotation switch to SW_HDG position
 			unsigned char buffer[4] = { 0x08,0,0,0 };
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 
 			buffer[0] |= 0x20; // set KNOB_PLUS to 1
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 			test_flight_loop(device);
 			Assert::AreEqual(1, test_get_dataref_value(dataref_str.c_str()));
 
 			buffer[0] &= (~0x20); // set KNOB_PLUS to 0
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 			test_flight_loop(device);
 			Assert::AreEqual(1, test_get_dataref_value(dataref_str.c_str()));
 
 			buffer[0] |= 0x40; // set KNOB_MINUS to 1
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 			test_flight_loop(device);
 			Assert::AreEqual(0, test_get_dataref_value(dataref_str.c_str()));
 
 			buffer[0] &= (~0x40); // set KNOB_MINUS to 0
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(250ms);
+			test_hid_read_wait_for_event(300);
 			test_flight_loop(device);
 			Assert::AreEqual(0, test_get_dataref_value(dataref_str.c_str()));
 		}
@@ -255,7 +256,7 @@ namespace test
 			// Press REV button
 			unsigned char buffer[4] = { 0,0x40,0,0 };
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 			test_flight_loop(device);
 			double ret_value=0;
 			LuaHelper::get_instance()->do_string("return get_hid_input_status('REV')", ret_value);
@@ -264,7 +265,7 @@ namespace test
 			// Release REV button
 			buffer[1] = 0;
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 			test_flight_loop(device);
 			LuaHelper::get_instance()->do_string("return get_hid_input_status('REV')", ret_value);
 			Assert::AreEqual(0, (int)ret_value);

--- a/test/test_multi_panel.cpp
+++ b/test/test_multi_panel.cpp
@@ -33,13 +33,13 @@ namespace test
 	{
 	private:
 		Configuration config;
-		Configparser* p;
+		ConfigParser* p;
 		SaitekMultiPanel* device;
 		std::thread* t;
 	public:
 		TEST_METHOD_INITIALIZE(TestMultiPanelInit)
 		{
-			p = new Configparser();
+			p = new ConfigParser();
 			int result = p->parse_file("../../test/test-valid-config.ini", config);
 			Assert::AreEqual(0, result);
 

--- a/test/test_radio_panel.cpp
+++ b/test/test_radio_panel.cpp
@@ -26,6 +26,7 @@ std::string test_get_last_command();
 void test_hid_get_write_data(unsigned char* data, size_t length);
 void test_flight_loop(Device* device);
 void test_hid_mock_init();
+bool test_hid_read_wait_for_event(int timeout_milliseconds);
 
 namespace test
 {
@@ -93,7 +94,7 @@ namespace test
 			// set rotation switch to SW_NAV_1 position
 			unsigned char buffer[4] = { 0x04,0,0,0 };
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 
 			test_flight_loop(device);
 			std::this_thread::sleep_for(150ms);
@@ -112,7 +113,7 @@ namespace test
 			// set rotation switch to SW_COM_2 position
 			unsigned char buffer[4] = { 0x02,0,0,0 };
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 
 			test_flight_loop(device);
 			std::this_thread::sleep_for(150ms);
@@ -132,7 +133,7 @@ namespace test
 			// set rotation switch to XPDR position
 			unsigned char buffer[4] = { 0x40,0,0,0 };
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 
 			test_flight_loop(device);
 			std::this_thread::sleep_for(150ms);
@@ -151,7 +152,7 @@ namespace test
 			// set rotation switch to SW_UP_ADF position
 			unsigned char buffer[4] = { 0x10,0,0,0 };
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 
 			test_flight_loop(device);
 			std::this_thread::sleep_for(150ms);
@@ -171,7 +172,7 @@ namespace test
 			// set rotation switch to SW_UP_DME position
 			unsigned char buffer[4] = { 0x20,0,0,0 };
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 
 			test_flight_loop(device);
 			std::this_thread::sleep_for(150ms);
@@ -190,14 +191,15 @@ namespace test
 			// set rotation switch to SW_NAV_1 position
 			unsigned char buffer[4] = { 0x04,0,0,0 };
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 
 			test_flight_loop(device);
 			std::this_thread::sleep_for(150ms);
 
 			buffer[2] |= 0x04; // set KNOB_UP_BIG_PLUS to 1
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
+
 			test_flight_loop(device);
 			Assert::AreEqual(11111 + 100, test_get_dataref_value(nav1_freq_dataref_str.c_str())); // nav1 freq shal be increased by +100
 			Assert::AreEqual(22222, test_get_dataref_value(nav2_freq_dataref_str.c_str())); // nav2 freq shall not change
@@ -206,7 +208,8 @@ namespace test
 
 			buffer[2] &= (~0x04); // set KNOB_UP_BIG_PLUS to 0
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
+
 			test_flight_loop(device);
 			Assert::AreEqual(11111 + 100, test_get_dataref_value(nav1_freq_dataref_str.c_str()));
 		}

--- a/test/test_radio_panel.cpp
+++ b/test/test_radio_panel.cpp
@@ -16,6 +16,7 @@
 #include "core/ConfigParser.h"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace std::literals;
 
 void test_hid_set_read_data(unsigned char* data, size_t length);
 int test_get_dataref_value(const char* datarefstr);

--- a/test/test_radio_panel.cpp
+++ b/test/test_radio_panel.cpp
@@ -33,7 +33,7 @@ namespace test
 	{
 	private:
 		Configuration config;
-		Configparser* p;
+		ConfigParser* p;
 		SaitekRadioPanel* device;
 		std::thread* t;
 		std::string nav1_freq_dataref_str = "sim/cockpit2/radios/actuators/nav1_frequency_hz";
@@ -55,7 +55,7 @@ namespace test
 		{
 			test_hid_mock_init();
 			
-			p = new Configparser();
+			p = new ConfigParser();
 			int result = p->parse_file("../../test/test-radio-panel-config.ini", config);
 			Assert::AreEqual(0, result);
 

--- a/test/test_radio_panel.cpp
+++ b/test/test_radio_panel.cpp
@@ -59,8 +59,8 @@ namespace test
 			int result = p->parse_file("../../test/test-radio-panel-config.ini", config);
 			Assert::AreEqual(0, result);
 
-			LuaHelper::get_instace()->init();
-			LuaHelper::get_instace()->load_script_file("../../test/" + config.script_file);
+			LuaHelper::get_instance()->init();
+			LuaHelper::get_instance()->load_script_file("../../test/" + config.script_file);
 
 			device = new SaitekRadioPanel(config.class_configs[0]);
 			device->connect();

--- a/test/test_trc1000_audio.cpp
+++ b/test/test_trc1000_audio.cpp
@@ -44,14 +44,14 @@ namespace test
 			int result = p->parse_file("../../test/test-trc1000-audio.ini", config);
 			Assert::AreEqual(0, result);
 
-			LuaHelper::get_instace()->init();
-			LuaHelper::get_instace()->load_script_file("../../test/" + config.script_file);
+			LuaHelper::get_instance()->init();
+			LuaHelper::get_instance()->load_script_file("../../test/" + config.script_file);
 
 			device = new TRC1000Audio(config.class_configs[0]);
 			device->connect();
 			device->start();
 			t = new std::thread(&TRC1000Audio::thread_func, (TRC1000Audio*)device);
-			LuaHelper::get_instace()->register_hid_device(device);
+			LuaHelper::get_instance()->register_hid_device(device);
 		}
 
 		TEST_METHOD(Test_VID_PID)

--- a/test/test_trc1000_audio.cpp
+++ b/test/test_trc1000_audio.cpp
@@ -16,6 +16,7 @@
 #include "core/ConfigParser.h"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace std::literals;
 
 void test_hid_set_read_data(unsigned char* data, size_t length);
 void test_hid_get_write_data(unsigned char* data, size_t length);
@@ -34,13 +35,13 @@ namespace test
 	{
 	private:
 		Configuration config;
-		Configparser* p;
+		ConfigParser* p;
 		TRC1000Audio* device;
 		std::thread* t;
 	public:
 		TEST_METHOD_INITIALIZE(TestTrc1000AudioPanelInit)
 		{
-			p = new Configparser();
+			p = new ConfigParser();
 			int result = p->parse_file("../../test/test-trc1000-audio.ini", config);
 			Assert::AreEqual(0, result);
 

--- a/test/test_trc1000_pfd.cpp
+++ b/test/test_trc1000_pfd.cpp
@@ -17,6 +17,7 @@
 #include "core/ConfigParser.h"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace std::literals;
 
 void test_hid_set_read_data(unsigned char* data, size_t length);
 int test_get_dataref_value(const char* datarefstr);
@@ -36,13 +37,13 @@ namespace test
 	{
 	private:
 		Configuration config;
-		Configparser* p;
+		ConfigParser* p;
 		TRC1000PFD* device;
 		std::thread* t;
 	public:
 		TEST_METHOD_INITIALIZE(TestTrc1000PFDPanelInit)
 		{
-			p = new Configparser();
+			p = new ConfigParser();
 			int result = p->parse_file("../../test/test-trc1000-pfd.ini", config);
 			Assert::AreEqual(0, result);
 

--- a/test/test_trc1000_pfd.cpp
+++ b/test/test_trc1000_pfd.cpp
@@ -46,14 +46,14 @@ namespace test
 			int result = p->parse_file("../../test/test-trc1000-pfd.ini", config);
 			Assert::AreEqual(0, result);
 
-			LuaHelper::get_instace()->init();
-			LuaHelper::get_instace()->load_script_file("../../test/" + config.script_file);
+			LuaHelper::get_instance()->init();
+			LuaHelper::get_instance()->load_script_file("../../test/" + config.script_file);
 
 			device = new TRC1000PFD(config.class_configs[0]);
 			device->connect();
 			device->start();
 			t = new std::thread(&TRC1000PFD::thread_func, (TRC1000PFD*)device);
-			LuaHelper::get_instace()->register_hid_device(device);
+			LuaHelper::get_instance()->register_hid_device(device);
 		}
 
 		TEST_METHOD(Test_VID_PID)

--- a/test/test_trc1000_pfd.cpp
+++ b/test/test_trc1000_pfd.cpp
@@ -29,7 +29,7 @@ int test_get_command_queue_size();
 void test_clear_command_queue();
 void test_hid_get_write_data(unsigned char* data, size_t length);
 void test_flight_loop(std::vector<ClassConfiguration> &config);
-
+bool test_hid_read_wait_for_event(int timeout_milliseconds);
 
 namespace test
 {
@@ -67,12 +67,12 @@ namespace test
 		{
 			unsigned char buffer[8] = { 0xC1, 0,0,0,0,0,0,0 };
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
-
+			test_hid_read_wait_for_event(300);
+			
 			buffer[1] = 0x40;
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
-
+			test_hid_read_wait_for_event(300);
+			
 			test_flight_loop(config.class_configs);
 			Assert::IsTrue(test_is_command_in_queue("sim/GPS/g1000n1_nav_ONCE"));
 		}
@@ -81,12 +81,12 @@ namespace test
 		{
 			unsigned char buffer[8] = { 0xC2, 127,0,0,0,0,0,0 };
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
-
+			test_hid_read_wait_for_event(300);
+			
 			buffer[1] = 129; // rotate encoder NAV_INNER by + 2
 			test_hid_set_read_data(buffer, sizeof(buffer));
-
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
+			
 			test_flight_loop(config.class_configs);
 			Assert::IsTrue(test_is_command_in_queue("sim/GPS/g1000n1_nav_inner_up_ONCE"));
 		}
@@ -95,12 +95,12 @@ namespace test
 		{
 			unsigned char buffer[8] = { 0xC2, 255,0,0,0,0,0,0 };
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 
 			buffer[1] = 2; // rotate encoder NAV_INNER by + 2
 			test_hid_set_read_data(buffer, sizeof(buffer));
+			test_hid_read_wait_for_event(300);
 
-			std::this_thread::sleep_for(150ms);
 			test_flight_loop(config.class_configs);
 			Assert::IsTrue(test_is_command_in_queue("sim/GPS/g1000n1_nav_inner_up_ONCE"));
 		}
@@ -109,15 +109,14 @@ namespace test
 		{
 			unsigned char buffer[8] = { 0xC2, 0,0,0,0,0,0,0 };
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 
 			buffer[1] = 1;
 			buffer[2] = 255;
 			test_hid_set_read_data(buffer, sizeof(buffer));
-
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
+			
 			test_flight_loop(config.class_configs);
-			std::this_thread::sleep_for(150ms);
 			Assert::IsFalse(test_is_command_in_queue("sim/GPS/g1000n1_nav_inner_up_ONCE"));
 		}
 
@@ -125,11 +124,11 @@ namespace test
 		{
 			unsigned char buffer[8] = { 0xC2, 2,0,0,0,0,0,0 };
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 
 			buffer[1] = 0; // rotate encoder NAV_INNER by - 2
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 
 			test_flight_loop(config.class_configs);
 			Assert::IsTrue(test_is_command_in_queue("sim/GPS/g1000n1_nav_inner_down_ONCE"));
@@ -139,11 +138,11 @@ namespace test
 		{
 			unsigned char buffer[8] = { 0xC2, 255,0,0,0,0,0,0 };
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 
 			buffer[1] = 1; // rotate encoder NAV_INNER by +2
 			test_hid_set_read_data(buffer, sizeof(buffer));
-			std::this_thread::sleep_for(150ms);
+			test_hid_read_wait_for_event(300);
 
 			test_clear_command_queue();
 			test_flight_loop(config.class_configs);

--- a/test/test_xpanel_plugin.cpp
+++ b/test/test_xpanel_plugin.cpp
@@ -16,6 +16,7 @@
 #include "core/ConfigParser.h"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace std::literals;
 
 void test_set_aircraft_path_and_filename(char* file_name, char* path);
 void test_call_registered_flight_loop();


### PR DESCRIPTION
1. Memory leak in ClassConfiguration::clear()
2. ClassConfiguration::operator= appends instead of replacing
3. Partially initialized `Action` constructors
4. Uninitialized variables in FIP image layer parsing
5. Use std::lock_guard instead of manual lock()/unlock()
6. Duplicate `#include` directives in Device.h
7. Device.h: move the use std::literals into c++ files
8. Typo in LuaHelper::get_instace()
9. Naming inconsistency: Configparser vs ConfigParser
10. Add error handling around USB HID open functions